### PR TITLE
Aligned error messages when searching for qualified beans.

### DIFF
--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/jms/JmsSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/jms/JmsSteps.java
@@ -62,7 +62,7 @@ public final class JmsSteps {
             return qualifiedBeanOfType(beanFactory, JmsHandler.class, broker);
         } catch (NoSuchBeanDefinitionException e) {
             throw new IllegalArgumentException(
-                "JmsSteps requires JmsHandler bean with qualifier [" + broker + "], but none was found", e);
+                "JmsSteps requires single JmsHandler bean with qualifier [" + broker + "]", e);
         }
     }
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/rest/RestServiceSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/rest/RestServiceSteps.java
@@ -90,7 +90,7 @@ public final class RestServiceSteps {
         try {
             return BeanFactoryAnnotationUtils.qualifiedBeanOfType(beanFactory, RestServiceHandler.class, application);
         } catch (NoSuchBeanDefinitionException e) {
-            throw new IllegalArgumentException("RestServiceSteps requires a RestServiceHandler bean with qualifier [" + application + "] but none was found", e);
+            throw new IllegalArgumentException("RestServiceSteps requires single RestServiceHandler bean with qualifier [" + application + "]", e);
         }
     }
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/sql/SqlSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/sql/SqlSteps.java
@@ -222,7 +222,7 @@ public final class SqlSteps {
             DataSource dataSource = BeanFactoryAnnotationUtils.qualifiedBeanOfType(beanFactory, DataSource.class, databaseId);
             return new NamedParameterJdbcTemplate(dataSource);
         } catch (NoSuchBeanDefinitionException e) {
-            throw new IllegalArgumentException("SqlSteps requires DataSource bean with qualifier [" + databaseId + "] but no was found", e);
+            throw new IllegalArgumentException("SqlSteps requires single DataSource bean with qualifier [" + databaseId + "]", e);
         }
     }
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/ws/WebServiceSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/ws/WebServiceSteps.java
@@ -115,7 +115,7 @@ public final class WebServiceSteps {
         try {
             return BeanFactoryAnnotationUtils.qualifiedBeanOfType(beanFactory, WebServiceHandler.class, application);
         } catch (NoSuchBeanDefinitionException e) {
-            throw new IllegalArgumentException("WebServiceSteps requires WebServiceHandler bean with qualifier [" + application + "] but no was found", e);
+            throw new IllegalArgumentException("WebServiceSteps requires single WebServiceHandler bean with qualifier [" + application + "]", e);
         }
     }
 


### PR DESCRIPTION
Resolves #32 - messages are now aligned to HealthCheckSteps example, 