### PR TITLE
Added commands for dateTime support

### DIFF
--- a/jbehave-support-core/docs/Expression-commands.md
+++ b/jbehave-support-core/docs/Expression-commands.md
@@ -10,10 +10,13 @@ List of commands:
 - [BYTES](#bytes)
 - [CONCAT](#concat)
 - [CURRENT_DATE](#current_date)
+- [CURRENT_DATE_TIME](#current_date_time)
 - [DATE_PARSE](#date_parse)
+- [DATE_TIME_PARSE](#date_time_parse)
 - [EMPTY_STRING](#empty_string)
 - [FILE](#file)
 - [FORMAT_DATE](#format_date)
+- [FORMAT_DATE_TIME](#format_date_time)
 - [LOWER_CASE](#lower_case)
 - [MAP](#map)
 - [NEXT_CALENDAR_DATE](#next_calendar_date)
@@ -21,6 +24,7 @@ List of commands:
 - [NULL](#null)
 - [PLUS](#plus)
 - [RANDOM_DATE](#random_date)
+- [RANDOM_DATE_TIME](#random_date_time)
 - [RANDOM_EMAIL](#random_email)
 - [RANDOM_NUMBER](#random_number)
 - [RANDOM_NUMBER_IN_RANGE](#random_number_in_range)
@@ -54,6 +58,14 @@ The CurrentDateCommand can be used in JBehave's tables in three ways:
 * ```{CURRENT_DATE:<number>}``` with numeric parameter, is evaluated to the current date shifted about given number of days
 * ```{CURRENT_DATE:<period>}``` with period parameter, is evaluated to the current day shifted about given period of time, see {@link Period#parse}
 
+#### CURRENT_DATE_TIME
+Current datetime command returns text form of current datetime. 
+
+The CurrentDateTimeCommand can be used in JBehave's tables in three ways:
+* ```{CURRENT_DATE_TIME}``` without parameter, is evaluated to the current datetime
+* ```{CURRENT_DATE_TIME:<number>}``` with numeric parameter, is evaluated to the current datetime shifted about given number of seconds
+* ```{CURRENT_DATE_TIME:<period>}``` with period parameter, is evaluated to the current datetime shifted about given period of time, see {@link Period#parse}
+
 #### DATE_PARSE
 Command for parsing date.
 Command consumes two arguments: 
@@ -63,6 +75,17 @@ Command consumes two arguments:
 > Example:
 > ``` 
 > {DATE_PARSE:05/20/2031:MM/dd/yyyy} 
+> ```
+
+#### DATE_TIME_PARSE
+Command for parsing datetime.
+Command consumes two arguments: 
+* datetime in string format 
+* format.
+
+> Example:
+> ``` 
+> {DATE_TIME_PARSE:10.15.30 05/20/2031:HH.mm.ss MM/dd/yyyy} 
 > ```
 
 #### EMPTY_STRING
@@ -92,8 +115,19 @@ Format date to expected format. Command consumes two arguments:
 
 > Example:
 > ```
-> {FORMAT_DATE:2031-05-20:MM/dd/yyyy
+> {FORMAT_DATE:2031-05-20:MM/dd/yyyy}
 > ```
+
+#### FORMAT_DATE_TIME
+Format datetime to expected format. Command consumes two arguments:
+* datetime in string format
+* output format
+
+> Example:
+> ```
+> {FORMAT_DATE_TIME:2031-05-20T10\:30\:11:MM/dd/yyyy HH:mm:ss}
+> ```
+
 
 #### LOWER_CASE
 This command takes one parameter that gets converted to lower case.
@@ -151,13 +185,22 @@ This command simply do the sum of parameters.
 > Result of the command: `7`
 
 #### RANDOM_DATE
-Command generate random date in range 1970 - 2059.
+Generates random date in range 1970 - 2059.
 
 > Example:
 > ```
 > {RANDOM_DATE}
 > ```
 > Result of the command: `LocalDate object`
+
+#### RANDOM_DATE_TIME
+Generates random datetime in range 1970 - 2059.
+
+> Example:
+> ```
+> {RANDOM_DATE_TIME}
+> ```
+> Result of the command: `LocalDateTime object`
 
 #### RANDOM_EMAIL
 Creates a valid random email according with fixed length.

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/RandomGeneratorHelper.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/RandomGeneratorHelper.java
@@ -1,6 +1,8 @@
 package org.jbehavesupport.core.internal;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -44,4 +46,15 @@ public final class RandomGeneratorHelper {
         long randomDay = RandomUtils.nextInt((int) minDay, (int) maxDay);
         return LocalDate.ofEpochDay(randomDay);
     }
+
+    public static LocalDateTime randomDateTime() {
+        LocalDate date = randomDate();
+        int hour = RandomUtils.nextInt(0, 24);
+        int minute = RandomUtils.nextInt(0, 60);
+        int second = RandomUtils.nextInt(0, 60);
+        LocalTime time = LocalTime.of(hour, minute, second);
+
+        return LocalDateTime.of(date, time);
+    }
+
 }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/CurrentDateCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/CurrentDateCommand.java
@@ -1,4 +1,4 @@
-package org.jbehavesupport.core.internal.expression;
+package org.jbehavesupport.core.internal.expression.temporal;
 
 import static org.springframework.util.Assert.isTrue;
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/CurrentDateTimeCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/CurrentDateTimeCommand.java
@@ -1,0 +1,49 @@
+package org.jbehavesupport.core.internal.expression.temporal;
+
+import static org.springframework.util.Assert.isTrue;
+
+import java.time.LocalDateTime;
+import java.time.Period;
+
+import lombok.RequiredArgsConstructor;
+import org.jbehavesupport.core.expression.ExpressionCommand;
+import org.jbehavesupport.core.support.TimeFacade;
+import org.springframework.stereotype.Component;
+
+/**
+ * The CurrentDateTimeCommand can be used in JBehave's tables in three ways:
+ *
+ * <ul>
+ * <li><code>{CURRENT_DATE_TIME}</code> without parameter, is evaluated to the current date based on {@link TimeFacade}</li>
+ * <li><code>{CURRENT_DATE_TIME:&lt;number&gt;}</code> with numeric parameter, is evaluated to the current date shifted about given number of seconds</li>
+ * <li><code>{CURRENT_DATE_TIME:&lt;period&gt;}</code> with period parameter, is evaluated to the current date shifted about given period of time, see {@link Period#parse}</li>
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+public class CurrentDateTimeCommand implements ExpressionCommand {
+
+    private final TimeFacade timeFacade;
+
+    @Override
+    public LocalDateTime execute(Object... params) {
+        isTrue(params.length < 2, "None or one parameter is expected");
+
+        LocalDateTime result;
+        LocalDateTime currentDate = timeFacade.getCurrentLocalDateTime();
+
+        if (params.length == 0) {
+            result = currentDate;
+        } else {
+            String param = params[0].toString();
+            if (param.startsWith("P")) {
+                Period period = Period.parse(param);
+                result = currentDate.plus(period);
+            } else {
+                int seconds = Integer.parseInt(param);
+                result = currentDate.plusSeconds(seconds);
+            }
+        }
+        return result;
+    }
+}

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/DateParseCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/DateParseCommand.java
@@ -1,0 +1,34 @@
+package org.jbehavesupport.core.internal.expression.temporal;
+
+import static org.springframework.util.Assert.isInstanceOf;
+import static org.springframework.util.Assert.isTrue;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.jbehavesupport.core.expression.ExpressionCommand;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Command for parsing date.
+ * Command consumes two arguments date in string format and format.
+ * E.g.:
+ * param1: "05/20/2031"
+ * param2: "MM/dd/yyyy"
+ */
+@Component
+public class DateParseCommand implements ExpressionCommand {
+
+    @Override
+    public Object execute(Object... params) {
+        isTrue(params.length == 2, "Two parameters were expected");
+        isInstanceOf(String.class, params[0], "First param must be string");
+        isInstanceOf(String.class, params[1], "Second param must be string");
+
+        String dateAsString = (String) params[0];
+        String dateFormat = (String) params[1];
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat);
+        return LocalDate.parse(dateAsString, dtf);
+    }
+}

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/DateTimeParseCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/DateTimeParseCommand.java
@@ -1,0 +1,33 @@
+package org.jbehavesupport.core.internal.expression.temporal;
+
+import static org.springframework.util.Assert.isInstanceOf;
+import static org.springframework.util.Assert.isTrue;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.jbehavesupport.core.expression.ExpressionCommand;
+import org.springframework.stereotype.Component;
+
+/**
+ * Command for parsing date.
+ * Command consumes two arguments date in string format and format.
+ * E.g.:
+ * param1: "2031-05-20T10:15:30"
+ * param2: "MM/dd/yyyy HH:mm:ss"
+ */
+@Component
+public class DateTimeParseCommand implements ExpressionCommand {
+
+    @Override
+    public Object execute(Object... params) {
+        isTrue(params.length == 2, "Two parameters were expected");
+        isInstanceOf(String.class, params[0], "First param must be string");
+        isInstanceOf(String.class, params[1], "Second param must be string");
+
+        String dateAsString = (String) params[0];
+        String dateFormat = (String) params[1];
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat);
+        return LocalDateTime.parse(dateAsString, dtf);
+    }
+}

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/FormatDateCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/FormatDateCommand.java
@@ -1,4 +1,4 @@
-package org.jbehavesupport.core.internal.expression;
+package org.jbehavesupport.core.internal.expression.temporal;
 
 import static org.springframework.util.Assert.isInstanceOf;
 import static org.springframework.util.Assert.isTrue;
@@ -11,24 +11,24 @@ import org.jbehavesupport.core.expression.ExpressionCommand;
 import org.springframework.stereotype.Component;
 
 /**
- * Command for parsing date.
- * Command consumes two arguments date in string format and format.
+ * Format date to expected format.
+ * Command consumes two arguments: date in string format and output format.
  * E.g.:
- * param1: "05/20/2031"
+ * param1: "2031-05-20"
  * param2: "MM/dd/yyyy"
  */
 @Component
-public class DateParseCommand implements ExpressionCommand {
+public class FormatDateCommand implements ExpressionCommand {
 
     @Override
     public Object execute(Object... params) {
         isTrue(params.length == 2, "Two parameters were expected");
-        isInstanceOf(String.class, params[0], "First param must be string");
-        isInstanceOf(String.class, params[1], "Second param must be string");
+        isInstanceOf(String.class, params[0], "First parameter must be string");
+        isInstanceOf(String.class, params[1], "Second parameter must be string");
 
-        String dateAsString = (String) params[0];
+        LocalDate input = LocalDate.parse((String) params[0]);
         String dateFormat = (String) params[1];
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat);
-        return LocalDate.parse(dateAsString, dtf);
+        return dtf.format(input);
     }
 }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/FormatDateTimeCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/FormatDateTimeCommand.java
@@ -1,24 +1,23 @@
-package org.jbehavesupport.core.internal.expression;
+package org.jbehavesupport.core.internal.expression.temporal;
 
 import static org.springframework.util.Assert.isInstanceOf;
 import static org.springframework.util.Assert.isTrue;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import org.jbehavesupport.core.expression.ExpressionCommand;
-
 import org.springframework.stereotype.Component;
 
 /**
- * Format date to expected format.
- * Command consumes two arguments: date in string format and output format.
+ * Format date time to expected format.
+ * Command consumes two arguments: date time in string format and output format.
  * E.g.:
- * param1: "2031-05-20"
- * param2: "MM/dd/yyyy"
+ * param1: "2031-05-20T10:15:30"
+ * param2: "MM/dd/yyyy HH:mm:ss"
  */
 @Component
-public class FormatDateCommand implements ExpressionCommand {
+public class FormatDateTimeCommand implements ExpressionCommand {
 
     @Override
     public Object execute(Object... params) {
@@ -26,7 +25,7 @@ public class FormatDateCommand implements ExpressionCommand {
         isInstanceOf(String.class, params[0], "First parameter must be string");
         isInstanceOf(String.class, params[1], "Second parameter must be string");
 
-        LocalDate input = LocalDate.parse((String) params[0]);
+        LocalDateTime input = LocalDateTime.parse((String) params[0]);
         String dateFormat = (String) params[1];
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateFormat);
         return dtf.format(input);

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/NextCalendarDayCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/NextCalendarDayCommand.java
@@ -1,4 +1,4 @@
-package org.jbehavesupport.core.internal.expression;
+package org.jbehavesupport.core.internal.expression.temporal;
 
 import static org.springframework.util.Assert.isTrue;
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/NextMonthCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/NextMonthCommand.java
@@ -1,4 +1,4 @@
-package org.jbehavesupport.core.internal.expression;
+package org.jbehavesupport.core.internal.expression.temporal;
 
 import static org.springframework.util.Assert.isTrue;
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/RandomDateCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/RandomDateCommand.java
@@ -1,4 +1,4 @@
-package org.jbehavesupport.core.internal.expression;
+package org.jbehavesupport.core.internal.expression.temporal;
 
 
 import static org.springframework.util.Assert.isTrue;

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/RandomDateTimeCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/temporal/RandomDateTimeCommand.java
@@ -1,0 +1,21 @@
+package org.jbehavesupport.core.internal.expression.temporal;
+
+
+import static org.springframework.util.Assert.isTrue;
+
+import org.jbehavesupport.core.expression.ExpressionCommand;
+import org.jbehavesupport.core.internal.RandomGeneratorHelper;
+import org.springframework.stereotype.Component;
+
+/**
+ * Generate random {@link java.time.LocalDateTime}
+ */
+@Component
+public class RandomDateTimeCommand implements ExpressionCommand {
+
+    @Override
+    public Object execute(Object... params) {
+        isTrue(params.length == 0, "No arguments are expected");
+        return RandomGeneratorHelper.randomDateTime();
+    }
+}

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/parameterconverters/LocalDateTimeConverter.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/parameterconverters/LocalDateTimeConverter.java
@@ -1,0 +1,20 @@
+package org.jbehavesupport.core.internal.parameterconverters;
+
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+
+import org.jbehave.core.steps.ParameterConverters;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalDateTimeConverter implements ParameterConverters.ParameterConverter {
+    @Override
+    public boolean accept(final Type type) {
+        return type == LocalDateTime.class;
+    }
+
+    @Override
+    public Object convertValue(final String s, final Type type) {
+        return LocalDateTime.parse(s);
+    }
+}

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/EmptyStringCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/EmptyStringCommandTest.groovy
@@ -1,7 +1,7 @@
 package org.jbehavesupport.core.expression
 
 
-import org.jbehavesupport.core.internal.expression.DateParseCommand
+import org.jbehavesupport.core.internal.expression.temporal.DateParseCommand
 import org.jbehavesupport.core.internal.expression.EmptyStringCommand
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/CurrentDateCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/CurrentDateCommandTest.groovy
@@ -1,7 +1,7 @@
-package org.jbehavesupport.core.expression
+package org.jbehavesupport.core.expression.temporal
 
 
-import org.jbehavesupport.core.internal.expression.CurrentDateCommand
+import org.jbehavesupport.core.internal.expression.temporal.CurrentDateCommand
 import org.jbehavesupport.core.support.TimeFacade
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/CurrentDateTimeCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/CurrentDateTimeCommandTest.groovy
@@ -1,0 +1,51 @@
+package org.jbehavesupport.core.expression.temporal
+
+import org.jbehavesupport.core.internal.expression.temporal.CurrentDateTimeCommand
+import org.jbehavesupport.core.support.TimeFacade
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+@Unroll
+class CurrentDateTimeCommandTest extends Specification {
+
+    def currentDateTimeCommand = new CurrentDateTimeCommand(TimeFacade.getDefault())
+
+    def "test execute with #expression returns #expected"() {
+        when:
+        def result = currentDateTimeCommand.execute(*expression)
+
+        then:
+        result.truncatedTo(ChronoUnit.SECONDS) == expected.truncatedTo(ChronoUnit.SECONDS)
+
+        where:
+        expression || expected
+        []         || LocalDateTime.now()
+        ["0"]      || LocalDateTime.now()
+        [0]        || LocalDateTime.now()
+        ["99"]     || LocalDateTime.now().plusSeconds(99)
+        [99]       || LocalDateTime.now().plusSeconds(99)
+        ["-20"]    || LocalDateTime.now().minusSeconds(20)
+        [-20]      || LocalDateTime.now().minusSeconds(20)
+        ["P2M3D"]  || LocalDateTime.now().plus(Period.parse("P2M3D"))
+    }
+
+    def "test execute with #expression throws #exception"() {
+        when:
+        currentDateTimeCommand.execute(*expression)
+
+        then:
+        thrown(exception)
+
+        where:
+        expression || exception
+        ["1", "2"] || IllegalArgumentException
+        ["123foo"] || NumberFormatException
+        ["P123"]   || DateTimeParseException
+    }
+
+}

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/DateParseCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/DateParseCommandTest.groovy
@@ -1,7 +1,7 @@
-package org.jbehavesupport.core.expression
+package org.jbehavesupport.core.expression.temporal
 
 
-import org.jbehavesupport.core.internal.expression.DateParseCommand
+import org.jbehavesupport.core.internal.expression.temporal.DateParseCommand
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/DateTimeParseCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/DateTimeParseCommandTest.groovy
@@ -1,0 +1,37 @@
+package org.jbehavesupport.core.expression.temporal
+
+
+import org.jbehavesupport.core.internal.expression.temporal.DateTimeParseCommand
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.LocalDateTime
+
+@Unroll
+class DateTimeParseCommandTest extends Specification {
+    def "test execute with #expression returns #expected"() {
+        when:
+        def result = new DateTimeParseCommand().execute(*expression)
+
+        then:
+        result == expected
+
+        where:
+        expression                   || expected
+        ["10:15:30 05/20/2031", "HH:mm:ss MM/dd/yyyy"] || LocalDateTime.of(2031, 05, 20, 10, 15, 30)
+    }
+
+    def "test execute with #expression throws #exception"() {
+        when:
+        new DateTimeParseCommand().execute(*expression)
+
+        then:
+        thrown(exception)
+
+        where:
+        expression                          || exception
+        ["1", "2", "3"]                     || IllegalArgumentException
+        [LocalDateTime.now(), "MM/dd/yyyy"] || IllegalArgumentException
+    }
+
+}

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/FormatDateCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/FormatDateCommandTest.groovy
@@ -1,7 +1,7 @@
-package org.jbehavesupport.core.expression
+package org.jbehavesupport.core.expression.temporal
 
 
-import org.jbehavesupport.core.internal.expression.FormatDateCommand
+import org.jbehavesupport.core.internal.expression.temporal.FormatDateCommand
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/FormatDateTimeCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/FormatDateTimeCommandTest.groovy
@@ -1,0 +1,36 @@
+package org.jbehavesupport.core.expression.temporal
+
+
+import org.jbehavesupport.core.internal.expression.temporal.FormatDateTimeCommand
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.LocalDateTime
+
+@Unroll
+class FormatDateTimeCommandTest extends Specification {
+    def "test execute with #expression returns #expected"() {
+        when:
+        def result = new FormatDateTimeCommand().execute(*expression)
+
+        then:
+        result == expected
+
+        where:
+        expression                   || expected
+        ["2031-05-20T10:15:30", "MM/dd/yyyy HH.mm.ss"] || "05/20/2031 10.15.30"
+    }
+
+    def "test execute with #expression throws #exception"() {
+        when:
+        new FormatDateTimeCommand().execute(*expression)
+
+        then:
+        thrown(exception)
+
+        where:
+        expression                          || exception
+        ["1", "2", "3"]                     || IllegalArgumentException
+        [LocalDateTime.now(), "MM/dd/yyyy"] || IllegalArgumentException
+    }
+}

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/NextCalendarDayCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/NextCalendarDayCommandTest.groovy
@@ -1,7 +1,7 @@
-package org.jbehavesupport.core.expression
+package org.jbehavesupport.core.expression.temporal
 
 
-import org.jbehavesupport.core.internal.expression.NextCalendarDayCommand
+import org.jbehavesupport.core.internal.expression.temporal.NextCalendarDayCommand
 import org.jbehavesupport.core.support.TimeFacade
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/NextMonthCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/NextMonthCommandTest.groovy
@@ -1,7 +1,7 @@
-package org.jbehavesupport.core.expression
+package org.jbehavesupport.core.expression.temporal
 
 
-import org.jbehavesupport.core.internal.expression.NextMonthCommand
+import org.jbehavesupport.core.internal.expression.temporal.NextMonthCommand
 import org.jbehavesupport.core.support.TimeFacade
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/RandomDateCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/RandomDateCommandTest.groovy
@@ -1,0 +1,32 @@
+package org.jbehavesupport.core.expression.temporal
+
+
+import org.jbehavesupport.core.internal.expression.temporal.RandomDateCommand
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+class RandomDateCommandTest extends Specification {
+
+    def "test random date generating"() {
+        when:
+        def result = new RandomDateCommand().execute()
+
+        then:
+        result != null
+        result instanceof LocalDate
+    }
+
+    def "test argument exception"() {
+        when:
+        new RandomDateCommand().execute(*params)
+
+        then:
+        Exception exception = thrown()
+        expected == exception.class
+
+        where:
+        params || expected
+        ["1"]  || IllegalArgumentException.class
+    }
+}

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/RandomDateTimeCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/RandomDateTimeCommandTest.groovy
@@ -1,25 +1,25 @@
-package org.jbehavesupport.core.expression
+package org.jbehavesupport.core.expression.temporal
 
 
-import org.jbehavesupport.core.internal.expression.RandomDateCommand
+import org.jbehavesupport.core.internal.expression.temporal.RandomDateTimeCommand
 import spock.lang.Specification
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 
-class RandomDateCommandTest extends Specification {
+class RandomDateTimeCommandTest extends Specification {
 
     def "test random date generating"() {
         when:
-        def result = new RandomDateCommand().execute()
+        def result = new RandomDateTimeCommand().execute()
 
         then:
         result != null
-        result instanceof LocalDate
+        result instanceof LocalDateTime
     }
 
     def "test argument exception"() {
         when:
-        new RandomDateCommand().execute(*params)
+        new RandomDateTimeCommand().execute(*params)
 
         then:
         Exception exception = thrown()


### PR DESCRIPTION
Solves #28 

Open points - NextMonth and NextCalendarDay commands - do we want datetime alternatives?
Do we want to add shortcodes for datetime parse and format date time similar to date versions? E.g.
``` 
shorthands.put("DP", "DATE_PARSE");
shorthands.put("FD", "FORMAT_DATE");
```