### PR TITLE
Changed Jaxb implementation to moxy

### DIFF
--- a/jbehave-support-core-test/jbehave-support-core-test-app/pom.xml
+++ b/jbehave-support-core-test/jbehave-support-core-test-app/pom.xml
@@ -144,8 +144,12 @@
             <artifactId>saaj-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.moxy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>

--- a/jbehave-support-core-test/jbehave-support-core-test-app/src/main/resources/META-INF/services/javax.xml.bind.JAXBContext
+++ b/jbehave-support-core-test/jbehave-support-core-test-app/src/main/resources/META-INF/services/javax.xml.bind.JAXBContext
@@ -1,0 +1,1 @@
+org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/jbehave-support-core-test/jbehave-support-core-test-oxm/src/main/resources/META-INF.services/javax.xml.bind.JAXBContext
+++ b/jbehave-support-core-test/jbehave-support-core-test-oxm/src/main/resources/META-INF.services/javax.xml.bind.JAXBContext
@@ -1,0 +1,1 @@
+org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/jbehave-support-core-test/pom.xml
+++ b/jbehave-support-core-test/pom.xml
@@ -29,6 +29,8 @@
         <version.commons-io>2.6</version.commons-io>
         <version.crash>1.3.2</version.crash>
         <version.jaxb-api>2.3.1</version.jaxb-api>
+        <version.moxy>2.7.4</version.moxy>
+        <version.mail-api>1.6.2</version.mail-api>
         <version.javax-activation>1.2.0</version.javax-activation>
         <version.javax.xml.soap-api>1.4.0</version.javax.xml.soap-api>
         <version.saaj-impl>1.5.1</version.saaj-impl>
@@ -85,9 +87,14 @@
                 <version>${version.saaj-impl}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>${version.jaxb-api}</version>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.moxy</artifactId>
+                <version>${version.moxy}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.mail</groupId>
+                <artifactId>javax.mail-api</artifactId>
+                <version>${version.mail-api}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.activation</groupId>

--- a/jbehave-support-core/pom.xml
+++ b/jbehave-support-core/pom.xml
@@ -309,8 +309,8 @@
             <artifactId>saaj-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.moxy</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>

--- a/jbehave-support-core/src/test/resources/META-INF/services/javax.xml.bind.JAXBContext
+++ b/jbehave-support-core/src/test/resources/META-INF/services/javax.xml.bind.JAXBContext
@@ -1,0 +1,1 @@
+org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <version.javax.xml.soap-api>1.4.0</version.javax.xml.soap-api>
         <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
         <version.jaxb-api>2.3.1</version.jaxb-api>
+        <version.moxy>2.7.4</version.moxy>
         <version.saaj-impl>1.5.1</version.saaj-impl>
         <version.javax-activation>1.2.0</version.javax-activation>
 
@@ -401,9 +402,9 @@
                 <version>${version.saaj-impl}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>${version.jaxb-api}</version>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.moxy</artifactId>
+                <version>${version.moxy}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.activation</groupId>


### PR DESCRIPTION
Moxy supports converters for java8 data types which were working before explicitly adding glassfish jaxb runtime.
I have not added test for it since it would include changing xjb, creating new LocalDate converter, changing test story, changing test ws and potentially changing test xsd (but if someone feels strongly about it I can do it, it just did not seem worth the hassle to me).