### PR TITLE
Duplicate ui mapping now throws IllegalStateException

### DIFF
--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/web/WebElementRegistryImpl.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/web/WebElementRegistryImpl.java
@@ -41,7 +41,9 @@ public class WebElementRegistryImpl implements WebElementRegistry {
         requireNonNull(elementName, "Parameter elementName is required.");
         requireNonNull(locator, "Parameter locator is required.");
         Map<String, By> elementRegistry = pageRegistry.computeIfAbsent(pageName, p -> new HashMap<>());
-        elementRegistry.put(elementName, locator);
+        if(elementRegistry.put(elementName, locator) != null){
+            throw new IllegalStateException("Web elements mapping contains duplicate key [" + elementName + "] for page [" + pageName + "].");
+        }
     }
 
 }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/web/YamlElementLocatorParser.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/web/YamlElementLocatorParser.java
@@ -53,7 +53,8 @@ public class YamlElementLocatorParser {
                     "Unable to parse given entry [" + key + ": " + value + "] "
                         + "in file [" + elementLocatorsResource.getFilename() + "], "
                         + "the expected format is: pageName.elementName[.locatorType], "
-                        + "where locator type is optional, supported values are "
+                        + "where element name must be unique for page and "
+                        + "locator type is optional, supported values are "
                         + "css (default) and xpath", e);
             }
         }


### PR DESCRIPTION
Today we faced issue where tester made duplicate mapping for page and system taken one of the mappings without throwing any error.
I tested behaviour manually by adding file with duplicate mapping.