### PR TITLE
RegexFindVerifier and Comparing of columns

### DIFF
--- a/jbehave-support-core/docs/General.md
+++ b/jbehave-support-core/docs/General.md
@@ -27,8 +27,8 @@ For some verification steps it's possible to use verifiers such as:
 `SIZE_EQ` - Size of collection is exactly expected value
 `SIZE_LT` - Size of collection is lower than expected value
 `SIZE_GT` - Size of collection is greater than expected value
-`REGEX_MATCH` - Matches String using regular expression
-`REGEX_FIND` - Check if regular expression matches any part of given value
+`REGEX_MATCH` - Matches String using regular expression - matches whole string
+`REGEX_FIND` - Check if regular expression matches any part of given value - matches data on one line
 
 The following sample step compares data from a ClientResponse from MYAPP against values in test context using operators.
 
@@ -40,17 +40,20 @@ Then [ClientResponse] values from [MYAPP] match:
 | client.cuid | NE       | {CP:CUID_3}   |
 ```
 
-Following step compares values in every row
+Following step compares values in every row (default verifier: EQ)
 
 ```
-Given following columns are compared:
-| actualValue                      | expectedValue | verifier   |
-| TEST                             | TEST          | EQ         |
-| TEST_CONTAINS                    | TEST          | CONTAINS   |
-
-Then following columns are compared:
-| actualValue       | expectedValue      | verifier |
-| {CP:ACTUAL_VALUE} |{CP:EXPECTED_VALUE} | EQ       |
+Then following data are compared:
+| data              | expectedValue      | verifier |
+| TEST              | TEST               | EQ       |
+| TEST_CONTAINS     | TEST               | CONTAINS |
+| {CP:ACTUAL_VALUE} |{CP:EXPECTED_VALUE} |          |
 ```
+
+#### Limiting verification error count in logs
+
+Verification steps use soft assertions to report errors - by default only first 10 comparison errors are reported (to avoid out of memory problems with long logs).  
+This number can be changed by setting the property `verifier.max.assert.count`.
+
 
 ---

--- a/jbehave-support-core/docs/General.md
+++ b/jbehave-support-core/docs/General.md
@@ -28,7 +28,7 @@ For some verification steps it's possible to use verifiers such as:
 `SIZE_LT` - Size of collection is lower than expected value
 `SIZE_GT` - Size of collection is greater than expected value
 `REGEX_MATCH` - Matches String using regular expression
-`REGEX_FIND` - Check if regular expression match any part of given value
+`REGEX_FIND` - Check if regular expression matches any part of given value
 
 The following sample step compares data from a ClientResponse from MYAPP against values in test context using operators.
 

--- a/jbehave-support-core/docs/General.md
+++ b/jbehave-support-core/docs/General.md
@@ -28,6 +28,7 @@ For some verification steps it's possible to use verifiers such as:
 `SIZE_LT` - Size of collection is lower than expected value
 `SIZE_GT` - Size of collection is greater than expected value
 `REGEX_MATCH` - Matches String using regular expression
+`REGEX_FIND` - Check if regular expression match any part of given value
 
 The following sample step compares data from a ClientResponse from MYAPP against values in test context using operators.
 
@@ -37,6 +38,19 @@ Then [ClientResponse] values from [MYAPP] match:
 | client.cuid | NE       | {CP:CUID_1}   |
 | client.cuid | NE       | {CP:CUID_2}   |
 | client.cuid | NE       | {CP:CUID_3}   |
+```
+
+Following step compares values in every row
+
+```
+Given following columns are compared:
+| actualValue                      | expectedValue | verifier   |
+| TEST                             | TEST          | EQ         |
+| TEST_CONTAINS                    | TEST          | CONTAINS   |
+
+Then following columns are compared:
+| actualValue       | expectedValue      | verifier |
+| {CP:ACTUAL_VALUE} |{CP:EXPECTED_VALUE} | EQ       |
 ```
 
 ---

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/ExampleTableConstraints.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/ExampleTableConstraints.java
@@ -8,7 +8,6 @@ public final class ExampleTableConstraints {
     public static final String NAME = "name";
     public static final String DATA = "data";
     public static final String ALIAS = "contextAlias";
-    public static final String ACTUAL_VALUE = "actualValue";
     public static final String EXPECTED_VALUE = "expectedValue";
     public static final String VERIFIER = "verifier";
     /**

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/ExampleTableConstraints.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/ExampleTableConstraints.java
@@ -8,6 +8,7 @@ public final class ExampleTableConstraints {
     public static final String NAME = "name";
     public static final String DATA = "data";
     public static final String ALIAS = "contextAlias";
+    public static final String ACTUAL_VALUE = "actualValue";
     public static final String EXPECTED_VALUE = "expectedValue";
     public static final String VERIFIER = "verifier";
     /**

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/RegexFindVerifier.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/RegexFindVerifier.java
@@ -14,6 +14,7 @@ public class RegexFindVerifier extends AbstractVerifier {
 
     public void verify(Object actual, Object expected) {
         Assert.notNull(actual, "Actual value must be provided");
+        Assert.notNull(expected, "Actual value must be provided");
         Matcher matcher = Pattern.compile(expected.toString()).matcher(actual.toString());
         if (!matcher.find()) {
             this.throwAssertionError("regex '%s' wasn't found in: \n%s", expected, actual);

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/RegexFindVerifier.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/RegexFindVerifier.java
@@ -14,7 +14,7 @@ public class RegexFindVerifier extends AbstractVerifier {
 
     public void verify(Object actual, Object expected) {
         Assert.notNull(actual, "Actual value must be provided");
-        Assert.notNull(expected, "Actual value must be provided");
+        Assert.notNull(expected, "Expected value must be provided");
         Matcher matcher = Pattern.compile(expected.toString()).matcher(actual.toString());
         if (!matcher.find()) {
             this.throwAssertionError("regex '%s' wasn't found in: \n%s", expected, actual);

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/RegexFindVerifier.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/RegexFindVerifier.java
@@ -1,0 +1,22 @@
+package org.jbehavesupport.core.internal.verification;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import static org.jbehavesupport.core.internal.verification.VerifierNames.REGEX_FIND;
+
+@Component
+public class RegexFindVerifier extends AbstractVerifier {
+    public String name() {
+        return REGEX_FIND;
+    }
+
+    public void verify(Object actual, Object expected) {
+        Assert.notNull(actual, "Actual value must be provided");
+        Matcher matcher = Pattern.compile(expected.toString()).matcher(actual.toString());
+        if (!matcher.find()) {
+            this.throwAssertionError("regex '%s' wasn't found in: \n%s", expected, actual);
+        }
+    }
+}

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/VerifierNames.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/verification/VerifierNames.java
@@ -11,6 +11,7 @@ public class VerifierNames {
     public static final String CONTAINS = "CONTAINS";
     public static final String NOT_CONTAINS = "NOT_CONTAINS";
     public static final String REGEX_MATCH = "REGEX_MATCH";
+    public static final String REGEX_FIND = "REGEX_FIND";
 
     public static final String GT = "GT";
     public static final String LT = "LT";

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
@@ -1,20 +1,17 @@
 package org.jbehavesupport.core.verification;
 
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.SoftAssertions;
 import org.codehaus.plexus.util.StringUtils;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.model.ExamplesTable;
-import org.jbehavesupport.core.internal.parameterconverters.ExamplesEvaluationTableConverter;
 import org.jbehavesupport.core.internal.verification.EqualsVerifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import static org.jbehavesupport.core.internal.ExampleTableConstraints.DATA;
 import static org.jbehavesupport.core.internal.ExampleTableConstraints.EXPECTED_VALUE;
 import static org.jbehavesupport.core.internal.ExampleTableConstraints.VERIFIER;
-import static org.jbehavesupport.core.internal.ExamplesTableUtil.convertTable;
 
 @Component
 @RequiredArgsConstructor
@@ -25,13 +22,11 @@ public class VerificationSteps {
 
     private final EqualsVerifier equalsVerifier;
     private final VerifierResolver verifierResolver;
-    private final ExamplesEvaluationTableConverter tableConverter;
 
-    @Then("following data are compared: $stringTable")
-    public void compareRows(String stringTable) {
-        List<Map<String, String>> convertedTable = convertTable((ExamplesTable) tableConverter.convertValue(stringTable, null));
+    @Then("following data are compared: $examplesTable")
+    public void compareRows(ExamplesTable examplesTable) {
         SoftAssertions softly = new SoftAssertions();
-        convertedTable.forEach(e -> verifyRow(e, softly));
+        examplesTable.getRows().forEach(e -> verifyRow(e, softly));
         softly.assertAll();
     }
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
@@ -2,6 +2,7 @@ package org.jbehavesupport.core.verification;
 
 import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.SoftAssertions;
 import org.codehaus.plexus.util.StringUtils;
 import org.jbehave.core.annotations.Given;
@@ -9,7 +10,6 @@ import org.jbehave.core.annotations.Then;
 import org.jbehave.core.model.ExamplesTable;
 import org.jbehavesupport.core.internal.parameterconverters.ExamplesEvaluationTableConverter;
 import org.jbehavesupport.core.internal.verification.VerifierNames;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import static org.jbehavesupport.core.internal.ExampleTableConstraints.ACTUAL_VALUE;
 import static org.jbehavesupport.core.internal.ExampleTableConstraints.EXPECTED_VALUE;
@@ -17,13 +17,11 @@ import static org.jbehavesupport.core.internal.ExampleTableConstraints.VERIFIER;
 import static org.jbehavesupport.core.internal.ExamplesTableUtil.convertTable;
 
 @Component
+@RequiredArgsConstructor
 public class VerificationSteps {
 
-    @Autowired
-    private VerifierResolver verifierResolver;
-
-    @Autowired
-    private ExamplesEvaluationTableConverter tableConverter;
+    private final VerifierResolver verifierResolver;
+    private final ExamplesEvaluationTableConverter tableConverter;
 
     @Given("following columns are compared: $stringTable")
     @Then("following columns are compared: $stringTable")

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
@@ -1,0 +1,48 @@
+package org.jbehavesupport.core.verification;
+
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.codehaus.plexus.util.StringUtils;
+import org.jbehave.core.annotations.Given;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.model.ExamplesTable;
+import org.jbehavesupport.core.internal.parameterconverters.ExamplesEvaluationTableConverter;
+import org.jbehavesupport.core.internal.verification.VerifierNames;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import static org.jbehavesupport.core.internal.ExampleTableConstraints.ACTUAL_VALUE;
+import static org.jbehavesupport.core.internal.ExampleTableConstraints.EXPECTED_VALUE;
+import static org.jbehavesupport.core.internal.ExampleTableConstraints.VERIFIER;
+import static org.jbehavesupport.core.internal.ExamplesTableUtil.convertTable;
+
+@Component
+public class VerificationSteps {
+
+    @Autowired
+    private VerifierResolver verifierResolver;
+
+    @Autowired
+    private ExamplesEvaluationTableConverter tableConverter;
+
+    @Given("following columns are compared: $stringTable")
+    @Then("following columns are compared: $stringTable")
+    public void compareRows(String stringTable) {
+        List<Map<String, String>> convertedTable = convertTable((ExamplesTable) tableConverter.convertValue(stringTable, null));
+        SoftAssertions softly = new SoftAssertions();
+        convertedTable.forEach(e -> verifyRow(e, verifierResolver.getVerifierByName(VerifierNames.CONTAINS), ACTUAL_VALUE, EXPECTED_VALUE, softly));
+        softly.assertAll();
+    }
+
+    private void verifyRow(Map<String, String> tableRow, Verifier verifier, String searchColumn1, String searchColumn2, SoftAssertions softly) {
+        if (softly.errorsCollected().size() >= 10) {
+            softly.assertAll();
+        }
+        softly.assertThatCode(() -> resolveVerifier(tableRow.get(VERIFIER), verifier).verify(tableRow.get(searchColumn1), tableRow.get(searchColumn2)))
+            .doesNotThrowAnyException();
+    }
+
+    private Verifier resolveVerifier(String verifierName, Verifier defaultVerifier) {
+        return (StringUtils.isNotEmpty(verifierName)) ? verifierResolver.getVerifierByName(verifierName) : defaultVerifier;
+    }
+}

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/verification/VerificationSteps.java
@@ -5,13 +5,13 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.SoftAssertions;
 import org.codehaus.plexus.util.StringUtils;
-import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.model.ExamplesTable;
 import org.jbehavesupport.core.internal.parameterconverters.ExamplesEvaluationTableConverter;
 import org.jbehavesupport.core.internal.verification.VerifierNames;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import static org.jbehavesupport.core.internal.ExampleTableConstraints.ACTUAL_VALUE;
+import static org.jbehavesupport.core.internal.ExampleTableConstraints.DATA;
 import static org.jbehavesupport.core.internal.ExampleTableConstraints.EXPECTED_VALUE;
 import static org.jbehavesupport.core.internal.ExampleTableConstraints.VERIFIER;
 import static org.jbehavesupport.core.internal.ExamplesTableUtil.convertTable;
@@ -20,20 +20,22 @@ import static org.jbehavesupport.core.internal.ExamplesTableUtil.convertTable;
 @RequiredArgsConstructor
 public class VerificationSteps {
 
+    @Value("${verifier.max.assert.count:10}")
+    private int maxSoftAssertCount;
+
     private final VerifierResolver verifierResolver;
     private final ExamplesEvaluationTableConverter tableConverter;
 
-    @Given("following columns are compared: $stringTable")
-    @Then("following columns are compared: $stringTable")
+    @Then("following data are compared: $stringTable")
     public void compareRows(String stringTable) {
         List<Map<String, String>> convertedTable = convertTable((ExamplesTable) tableConverter.convertValue(stringTable, null));
         SoftAssertions softly = new SoftAssertions();
-        convertedTable.forEach(e -> verifyRow(e, verifierResolver.getVerifierByName(VerifierNames.CONTAINS), ACTUAL_VALUE, EXPECTED_VALUE, softly));
+        convertedTable.forEach(e -> verifyRow(e, verifierResolver.getVerifierByName(VerifierNames.EQ), DATA, EXPECTED_VALUE, softly));
         softly.assertAll();
     }
 
     private void verifyRow(Map<String, String> tableRow, Verifier verifier, String searchColumn1, String searchColumn2, SoftAssertions softly) {
-        if (softly.errorsCollected().size() >= 10) {
+        if (softly.errorsCollected().size() >= maxSoftAssertCount) {
             softly.assertAll();
         }
         softly.assertThatCode(() -> resolveVerifier(tableRow.get(VERIFIER), verifier).verify(tableRow.get(searchColumn1), tableRow.get(searchColumn2)))

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/RegexFindVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/RegexFindVerifierTest.groovy
@@ -46,7 +46,7 @@ class RegexFindVerifierTest extends Specification {
         where:
         actual  | expected || message
         null    | "asd"    || "Actual value must be provided"
-        "asd"   | null     || "Actual value must be provided"
+        "asd"   | null     || "Expected value must be provided"
         "wrong" | ".*good" || "regex '.*good' wasn't found in: \nwrong"
     }
 

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/RegexFindVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/RegexFindVerifierTest.groovy
@@ -1,0 +1,54 @@
+package org.jbehavesupport.core.internal.verification
+
+import org.jbehavesupport.core.TestConfig
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@ContextConfiguration(classes = TestConfig)
+class RegexFindVerifierTest extends Specification {
+
+    @Autowired
+    RegexFindVerifier regexFindVerifier;
+
+    def "Name"() {
+        expect:
+        regexFindVerifier.name().equals("REGEX_FIND");
+    }
+
+    @Unroll
+    "VerifyPositive #actual to #expected"() {
+        when:
+        regexFindVerifier.verify(actual, expected);
+
+        then:
+        true
+
+        where:
+        actual     | expected
+        "XXtestXX" | ".*test.*"
+        "test"     | ".*test.*"
+        "te45st"   | ".*\\d+.*"
+        "testdata" | "e[stuv]t"
+
+    }
+
+    @Unroll
+    "VerifyNegative #actual to #expected"() {
+        when:
+        regexFindVerifier.verify(actual, expected);
+
+        then:
+        def exception = thrown(Throwable)
+        exception.getMessage() == message
+
+        where:
+        actual  | expected || message
+        null    | "asd"    || "Actual value must be provided"
+        "asd"   | null     || "Actual value must be provided"
+        "wrong" | ".*good" || "regex '.*good' wasn't found in: \nwrong"
+    }
+
+
+}

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/RegexFindVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/RegexFindVerifierTest.groovy
@@ -14,13 +14,13 @@ class RegexFindVerifierTest extends Specification {
 
     def "Name"() {
         expect:
-        regexFindVerifier.name().equals("REGEX_FIND");
+        regexFindVerifier.name().equals("REGEX_FIND")
     }
 
     @Unroll
     "VerifyPositive #actual to #expected"() {
         when:
-        regexFindVerifier.verify(actual, expected);
+        regexFindVerifier.verify(actual, expected)
 
         then:
         true
@@ -37,7 +37,7 @@ class RegexFindVerifierTest extends Specification {
     @Unroll
     "VerifyNegative #actual to #expected"() {
         when:
-        regexFindVerifier.verify(actual, expected);
+        regexFindVerifier.verify(actual, expected)
 
         then:
         def exception = thrown(Throwable)

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/SampleStoriesIT.java
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/SampleStoriesIT.java
@@ -26,7 +26,8 @@ public class SampleStoriesIT extends AbstractSpringStories {
             "org/jbehavesupport/test/sample/WebNavigation.story",
             "org/jbehavesupport/test/sample/Ssh.story",
             "org/jbehavesupport/test/sample/HealthCheck.story",
-            "org/jbehavesupport/test/sample/Jms.story"
+            "org/jbehavesupport/test/sample/Jms.story",
+            "org/jbehavesupport/test/sample/Verification.story"
         );
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Verification.story
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Verification.story
@@ -1,0 +1,10 @@
+Scenario: Test comparison of columns and REGEX_VERIFIER
+
+Given following columns are compared:
+| actualValue                      | expectedValue | verifier   |
+| TEST                             | TEST          | EQ         |
+| TEST_CONTAINS                    | TEST          | CONTAINS   |
+| TEST_REGEX                       | [OPQRS]E.*?E  | REGEX_FIND |
+| {MAP:0:[0,Zero],[1,One]}         | Zero          | EQ         |
+| {MAP:{NULL}:[{NULL},NOT_NULL]}   | NOT_NULL      | EQ         |
+| {NULL}                           | {NULL}        | EQ         |

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Verification.story
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Verification.story
@@ -1,10 +1,10 @@
 Scenario: Test comparison of columns and REGEX_VERIFIER
 
-Given following columns are compared:
-| actualValue                      | expectedValue | verifier   |
+Then following data are compared:
+| data                             | expectedValue | verifier   |
 | TEST                             | TEST          | EQ         |
 | TEST_CONTAINS                    | TEST          | CONTAINS   |
 | TEST_REGEX                       | [OPQRS]E.*?E  | REGEX_FIND |
 | {MAP:0:[0,Zero],[1,One]}         | Zero          | EQ         |
 | {MAP:{NULL}:[{NULL},NOT_NULL]}   | NOT_NULL      | EQ         |
-| {NULL}                           | {NULL}        | EQ         |
+| {NULL}                           | {NULL}        |            |


### PR DESCRIPTION
REGEX_FIND verifier is best used for in log checks. Like 
| myAppRequest.*?{CP:INDENTIFIER}.*?testedValue>{CP:TESTED_VALUE}<.*?myAppRequest | REGEX_FIND|.

Steps for columns comparing is good for comparing SQL resutls with many columns, because writing 100 columns on one line is really ugly., so it;s better to save all values from both selects to context and compare them in another step. Of course it have mutch more examples of usage.