### PR TITLE
Fixed Firefox

### DIFF
--- a/jbehave-support-core/src/main/resources/index.xslt
+++ b/jbehave-support-core/src/main/resources/index.xslt
@@ -1,8 +1,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:output method="html" indent="yes"/>
+    <xsl:output method="html" doctype-system="about:legacy-compat"/>
 
     <xsl:template match="/">
-        <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
         <html>
             <head>
                 <meta charset="utf-8"/>

--- a/jbehave-support-core/src/main/resources/report.xslt
+++ b/jbehave-support-core/src/main/resources/report.xslt
@@ -11,7 +11,7 @@
     <xsl:import href="report-generator/screenshotReport.xslt"/>
     <xsl:import href="report-generator/jmsXmlReport.xslt"/>
 
-    <xsl:output method="html" indent="yes"/>
+    <xsl:output method="html" doctype-system="about:legacy-compat"/>
 
     <xsl:template name="textColor">
         <xsl:param name="outcome"/>
@@ -35,7 +35,6 @@
     </xsl:template>
 
     <xsl:template match="/">
-        <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
         <html>
             <head>
                 <meta charset="utf-8"/>


### PR DESCRIPTION
Fixed switching between reports and removed the text "!DOCTYPE html" in top left corner in Firefox

Fixes #177 