### PR TITLE
Loading screenshots from custom directory to xml reports

### DIFF
--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/web/WebScreenshotCreator.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/web/WebScreenshotCreator.java
@@ -45,6 +45,7 @@ public class WebScreenshotCreator {
     public static final String FAILED_SCREENSHOTS_KEY = "error_screenshots";
     public static final String REPORT_SCREENSHOTS_KEY = "report_screenshots";
     private static final String FILE_NAME_PATTERN = "%s_%s.png";
+    public static final String SCREENSHOTS_DIRECTORY_KEY = "screenshotDirectory";
 
     /**
      * All types except FAILED are in development, so it's not recommended to use them.
@@ -110,9 +111,9 @@ public class WebScreenshotCreator {
     }
 
     private void prepareDirectory() throws IOException {
+        testContext.put(SCREENSHOTS_DIRECTORY_KEY, screenshotDirectory);
         if (!Paths.get(screenshotDirectory).toFile().exists()) {
             Files.createDirectory(Paths.get(screenshotDirectory));
-            testContext.put("screenshotDirectory", screenshotDirectory);
         }
     }
 

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/report/extension/FailScreenshotsReporterExtension.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/report/extension/FailScreenshotsReporterExtension.java
@@ -1,6 +1,8 @@
 package org.jbehavesupport.core.report.extension;
 
 import java.io.Writer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ public class FailScreenshotsReporterExtension extends AbstractXmlReporterExtensi
 
     private static final String FAIL_SCREENSHOTS_REPORTER_EXTENSION = "errorScreenshots";
     private static final String SCREENSHOT_TAG = "<screenshot>%s</screenshot>";
+    private static final String RELATIVE_PATH_ADJUSTER = "../../";
 
     private final TestContext testContext;
 
@@ -37,8 +40,11 @@ public class FailScreenshotsReporterExtension extends AbstractXmlReporterExtensi
     public void print(final Writer writer, final ReportContext reportContext) {
         if (testContext.contains(WebScreenshotCreator.FAILED_SCREENSHOTS_KEY)) {
             Set<String> screenshots = testContext.get(WebScreenshotCreator.FAILED_SCREENSHOTS_KEY, Set.class);
+            String screenshotDirectory = testContext.get(WebScreenshotCreator.SCREENSHOTS_DIRECTORY_KEY, String.class);
             for (String screenshotName : screenshots) {
-                printScreenshotEntry(writer, screenshotName);
+                Path path = Paths.get(screenshotDirectory, screenshotName);
+                String pathString = path.isAbsolute() ? path.toString() : RELATIVE_PATH_ADJUSTER + path.toString();
+                printScreenshotEntry(writer, pathString);
             }
         }
     }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/report/extension/ScreenshotReporterExtension.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/report/extension/ScreenshotReporterExtension.java
@@ -1,6 +1,8 @@
 package org.jbehavesupport.core.report.extension;
 
 import java.io.Writer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ public class ScreenshotReporterExtension extends AbstractXmlReporterExtension {
 
     private static final String STEP_SCREENSHOTS_REPORTER_EXTENSION = "stepScreenshots";
     private static final String SCREENSHOT_TAG = "<stepScreenshot>%s</stepScreenshot>";
+    private static final String RELATIVE_PATH_ADJUSTER = "../../";
     private final TestContext testContext;
 
     @Override
@@ -28,8 +31,11 @@ public class ScreenshotReporterExtension extends AbstractXmlReporterExtension {
     public void print(final Writer writer, final ReportContext reportContext) {
         if (testContext.contains(WebScreenshotCreator.REPORT_SCREENSHOTS_KEY)) {
             Set<String> screenshots = testContext.get(WebScreenshotCreator.REPORT_SCREENSHOTS_KEY, Set.class);
+            String screenshotDirectory = testContext.get(WebScreenshotCreator.SCREENSHOTS_DIRECTORY_KEY, String.class);
             for (String screenshotName : screenshots) {
-                printScreenshotEntry(writer, screenshotName);
+                Path path = Paths.get(screenshotDirectory, screenshotName);
+                String pathString = path.isAbsolute() ? path.toString() : RELATIVE_PATH_ADJUSTER + path.toString();
+                printScreenshotEntry(writer, pathString);
             }
         }
     }


### PR DESCRIPTION
The path to a screenshot is now written to the xml, not just the file name.