### PR TITLE
SshSteps.readLog() public access

### DIFF
--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/ssh/SshSteps.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/ssh/SshSteps.java
@@ -70,7 +70,7 @@ public final class SshSteps {
         logCache.clear();
     }
 
-    private String readLog(String systemQualifier, ZonedDateTime startTime, ZonedDateTime endTime) {
+    public String readLog(String systemQualifier, ZonedDateTime startTime, ZonedDateTime endTime) {
         if (logCache.containsKey(startTime, endTime, systemQualifier)) {
             log.info("Log found in cache.");
             return logCache.get(startTime, endTime, systemQualifier);


### PR DESCRIPTION
I would like to make readLog() public. So projects that are using some custom ssh logic, can utilize sshSteps too.