### PR TITLE
WIP: Updated CI latest java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 13 ]
+        java: [ 8, 11, 14 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 13 ]
+        java: [ 8, 11, 14 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 13 ]
+        java: [ 8, 11, 14 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
WIP so far - we will need to update Groovy first (current version does not support Java 14) - which will need to wait till Spock releases compliant version for groovy 3 😞 