### PR TITLE
Added option to send empty node in WS steps.

### DIFF
--- a/jbehave-support-core/docs/Web-service.md
+++ b/jbehave-support-core/docs/Web-service.md
@@ -56,6 +56,26 @@ When [ClientRequest] is sent to [MYAPP] with fault:
 ```
 Note the special `faultCode` and `faultReason` parameters that can be checked (either one of them or both can be checked).
 
+### Sending NIL values
+A special `NIL` command can be used for sending nil values:
+> ``` 
+> [$request] data for [$application]:  
+> | name        | data  |  
+> | Foo.validTo | {NIL} |
+> ```
+The above will result in something like `<Foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><validTo xsi:nil="true"/></Foo>`.
+
+### Sending Empty values
+An empty node (`<node/>`) can be sent by se setting the required node using the `NULL` command:
+> ``` 
+> [$request] data for [$application]:  
+> | name        | data   |  
+> | Foo.validTo | {NULL} |
+> ```
+The above will result in something like `<Foo><validTo/></Foo>`.
+
+When using the `NULL` command the node gets sent with empty value, when not specifying any value at all (not specifying the key in the table) the node does not get sent at all.
+
 
 ---
 ### Custom type converters

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/support/RequestFactory.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/support/RequestFactory.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
 import static org.apache.commons.lang3.ClassUtils.isAssignable;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.util.StringUtils.isEmpty;
 
 import java.beans.PropertyDescriptor;
@@ -292,14 +293,14 @@ public class RequestFactory<REQUEST> {
         if (metaType != null) {
             return instantiateClass(metaType);
         }
-        if (value == null) {
-            value = null;
-        } else if (isAssignable(type, JAXBElement.class)) { //Very tricky to extract to converter
+        if (isAssignable(type, JAXBElement.class)) { //Very tricky to extract to converter
             value = resolveJaxbElement(testContext, key, value);
+        } else if (value == null) {
+            value = instantiateClass(type);
         } else if (conversionService.canConvert(value.getClass(), type)) {
             value = conversionService.convert(value, type);
         }
-        Assert.isTrue(!(value == null && isAbstract(type)), "Please specify type for " + key);
+        assertThat(value == null && isAbstract(type)).withFailMessage("Please specify type for " + key).isFalse();
         return value;
     }
 

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/WebServiceTestIT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/WebServiceTestIT.groovy
@@ -1,11 +1,13 @@
 package org.jbehavesupport.core.ws
 
+import org.jbehave.core.configuration.MostUsefulConfiguration
 import org.jbehave.core.model.ExamplesTable
+import org.jbehave.core.steps.ParameterConverters
 import org.jbehavesupport.core.TestConfig
-import org.jbehavesupport.core.test.app.domain.Address
+import org.jbehavesupport.core.internal.parameterconverters.ExamplesEvaluationTableConverter
+import org.jbehavesupport.core.internal.parameterconverters.NullStringConverter
 import org.jbehavesupport.core.test.app.oxm.AddressInfo
 import org.jbehavesupport.core.test.app.oxm.NameRequest
-import org.jbehavesupport.core.test.app.oxm.NameResponse
 import org.junit.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
@@ -17,10 +19,16 @@ class WebServiceTestIT extends Specification{
     @Autowired
     private WebServiceHandler webServiceHandler
 
+    @Autowired
+    private ExamplesEvaluationTableConverter converter
+
+    @Autowired
+    private NullStringConverter nullStringConverter
+
     private NameRequest request
 
     @Test
-    void canUseNestedListsWithDifferentNotations(){
+    void canUseNestedListsWithDifferentNotations() {
         given:
         ExamplesTable data = new ExamplesTable(
             "| name                                  | data  |\n" +
@@ -50,4 +58,28 @@ class WebServiceTestIT extends Specification{
         addressInfoList[1].details[0] == "10"
         addressInfoList[1].details[1] == "11"
     }
+
+    @Test
+    void canFillEmptyElement() {
+        given:
+        def paramsConverters = new ParameterConverters().addConverters(nullStringConverter)
+        converter.setConfiguration(new MostUsefulConfiguration().useParameterConverters(paramsConverters))
+
+        def tableData =
+            "| name                           | data   |\n" +
+            "| addressList.addressInfo.0.city | Praha  |\n" +
+            "| cell                           | {NULL} |"
+        ExamplesTable data = converter.convertValue(tableData, ExamplesTable.class)
+
+        when:
+        webServiceHandler.setRequestData("NameRequest", data)
+        request = webServiceHandler.createRequest(NameRequest.class, null)
+
+        then:
+        noExceptionThrown()
+        request.addressList.addressInfo[0].city == "Praha"
+        request.cell != null
+        request.name == null
+    }
+
 }


### PR DESCRIPTION
Resolves #100 

One of the possible solutions - alternative could be to use different command than NULL, but IMO not setting in examples table=not sent, setting explicitly to null=empty node sounds reasonable from end users perspective... But feel free to suggest another solution if this does not work for you.