### PR TITLE
Fixed the README tutorial to suggest a test directory for story files…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The `elementLocatorsSource` methods sets the name of a [file](#create-a-ui-mappi
 
 ### Create a ui mapping file
 
-In this yaml file, we need to setup the links to web page elements we want to interact with. I has to be placed in the resources directory, which is on one level above your main code directory:
+In this yaml file, we need to setup the links to web page elements we want to interact with. It has to be placed in the resources directory, which is on one level above your main code directory:
 - Project
     - src
         - main
@@ -124,7 +124,14 @@ In this yaml file, we need to setup the links to web page elements we want to in
                 - your.main.code.directory
             - **resources**
                 - home.yaml
+        - test
+            - java
+                - your.test.code.directory
             
+At this point, `your.main.code.directory` should contain the TestConfig class created previously.  
+Note also the location of `your.test.code.directory` — this is where your story files will go later.
+
+
 The links and names should be written like this:
 ```
 home:
@@ -144,9 +151,9 @@ The part after the colon is the address of the element itself.
 
 ### Write your story
 
-In your `your.main.code.directory` directory create a `.story` file. I will call it `Google.story`.
+In your `your.test.code.directory` directory create a `.story` file. I will call it `Google.story`.
 
-_(Optional)_ Inside write the narrative, which should explain what is the purpose of this story. It has 3 mandatory parts: `In order to`, `As a` and `I want to`.
+_(Optional)_ Inside, write the narrative, which should explain the purpose of this story. It has 3 mandatory parts: `In order to`, `As a` and `I want to`.
 ```
 Narrative:
 In order to try jbehave-support
@@ -171,7 +178,7 @@ This scenario opens `www.google.com`, writes `embeditcz jbehave-support` into th
 
 ### Write your story class
 
-In the same directory as your `.story` file create a Java class that extends `AbstractSpringStories` and call it `<yourStoryName>Story` (naming is important). Add the annotation `@ContextConfiguration(classes = TestConfig.class)` to link it with your TextConfig class. Leave this class empty.
+In the same directory as your `.story` file, create a Java class that extends `AbstractSpringStories` and call it `<yourStoryName>Story` (naming is important). Add the annotation `@ContextConfiguration(classes = TestConfig.class)` to link it with your TextConfig class. Leave this class empty.
 ```
 @ContextConfiguration(classes = TestConfig.class)
 public class GoogleStory extends AbstractSpringStories {


### PR DESCRIPTION
… (previously, it implied that the tests should be in the /main/java/ directory, however, this was not aligned with another part of the tutorial which instructed the user to add a pom definition which marked the test directory as the actual location of the story files. If the user followed the tutorial strictly, it resulted in a seemingly successful test run, which, however, ended up not running any of the stories (because they would actually be in the /main/java/ directory). Also a minor English fix.