### PR TITLE
BrowserStack Local rewrite

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -29,6 +29,20 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username: ${{ env.BROWSERSTACK_USER }}
+          access-key: ${{ env.BROWSERSTACK_KEY }}
+      - name: BrowserStack Local Setup
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: start
+          local-identifier: random
       - name: BrowserStack${{ matrix.browser }}T on Java ${{ matrix.java }}
         run: |
           xvfb-run mvn verify -DskipUnitTests=true -Djbehave.report.level=STORY -Dbrowser-stack.username=${BROWSERSTACK_USER} -Dbrowser-stack.key=${BROWSERSTACK_KEY} -Dit.test=**/BrowserStack${{ matrix.browser }}T -Pintegration-test -B -V
+      - name: BrowserStack Local Stop
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: stop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,10 @@ Sample stories (`jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sa
 ## Multi-browser testing
 We test our code against Chrome, Safari and Firefox browsers. Tests are not running in a pipeline before PR but after it in master branch.
 
-To be able to run test in your local branch please fill your BrowserStack credentials into environment variables: `BROWSER-STACK_USERNAME`, `BROWSER-STACK_KEY` (overwrites properties in test.yml).
+To be able to run BrowserStack specific test in your local branch please:
+ * fill your BrowserStack credentials into environment variables: `BROWSER-STACK_USERNAME`, `BROWSER-STACK_KEY` (overwrites properties in test.yml)
+ * run the BrowserStack Local binary on your system, please refer to [BrowserStack documentation](https://www.browserstack.com/local-testing/automate#command-line) 
+   for the correct download link and usage
 
 
 ## Release

--- a/jbehave-support-core/pom.xml
+++ b/jbehave-support-core/pom.xml
@@ -390,10 +390,5 @@
             <artifactId>byte-buddy</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.browserstack</groupId>
-            <artifactId>browserstack-local-java</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackChromeT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackChromeT.groovy
@@ -12,6 +12,7 @@ import static org.jbehavesupport.test.support.TestConfig.CHROME_BROWSERSTACK
 
 /**
  * This test verifies that our code is compatible with Chrome using BrowserStack.
+ * It assumes BrowserStack Local binary is already running.
  */
 @ContextConfiguration(classes = TestConfig.class)
 class BrowserStackChromeT extends Specification implements TestSupportBrowserStack {
@@ -25,11 +26,6 @@ class BrowserStackChromeT extends Specification implements TestSupportBrowserSta
     def setup() {
         System.setProperty("web.browser", CHROME_BROWSERSTACK)
         System.setProperty("browser-stack.build", getBuildName())
-        setupBrowserStackLocal(env.getProperty("browser-stack.key"))
-    }
-
-    def cleanupSpec() {
-        stopBrowserStackLocal()
     }
 
     def "Chrome test #story"() {

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackFirefoxT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackFirefoxT.groovy
@@ -12,6 +12,7 @@ import static org.jbehavesupport.test.support.TestConfig.FIREFOX_BROWSERSTACK
 
 /**
  * This test verifies that our code is compatible with Firefox using BrowserStack.
+ * It assumes BrowserStack Local binary is already running.
  */
 @ContextConfiguration(classes = TestConfig.class)
 class BrowserStackFirefoxT extends Specification implements TestSupportBrowserStack {
@@ -25,11 +26,6 @@ class BrowserStackFirefoxT extends Specification implements TestSupportBrowserSt
     def setup() {
         System.setProperty("web.browser", FIREFOX_BROWSERSTACK)
         System.setProperty("browser-stack.build", getBuildName())
-        setupBrowserStackLocal(env.getProperty("browser-stack.key"))
-    }
-
-    def cleanupSpec() {
-        stopBrowserStackLocal()
     }
 
     def "Firefox test #story"() {

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackSafariT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackSafariT.groovy
@@ -13,6 +13,7 @@ import static org.jbehavesupport.test.support.TestConfig.SAFARI_BROWSERSTACK
 
 /**
  * This test verifies that our code is compatible with Safari using BrowserStack.
+ * It assumes BrowserStack Local binary is already running.
  */
 @ContextConfiguration(classes = TestConfig.class)
 class BrowserStackSafariT extends Specification implements TestSupportBrowserStack {
@@ -27,11 +28,6 @@ class BrowserStackSafariT extends Specification implements TestSupportBrowserSta
         System.setProperty("web.browser", SAFARI_BROWSERSTACK)
         System.setProperty("web.url", "http://bs-local.com:11110/")
         System.setProperty("browser-stack.build", getBuildName())
-        setupBrowserStackLocal(env.getProperty("browser-stack.key"))
-    }
-
-    def cleanupSpec() {
-        stopBrowserStackLocal()
     }
 
     def "Safari test #story"() {

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestConfig.java
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestConfig.java
@@ -337,6 +337,9 @@ public class TestConfig {
         capabilities.setCapability("browserstack.selenium_version", "3.141.59");
         capabilities.setCapability("name", env.getProperty("browser-stack.name"));
         capabilities.setCapability("build", env.getProperty("browser-stack.build"));
+        if (nonNull(env.getProperty("browserstack.local.identifier"))) {
+            capabilities.setCapability("browserstack.localIdentifier", env.getProperty("browserstack.local.identifier"));
+        }
 
         RemoteWebDriver driver = new RemoteWebDriver(new URL(env.getProperty("browser-stack.url")), capabilities);
         driver.manage().window().maximize();

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestSupportBrowserStack.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestSupportBrowserStack.groovy
@@ -1,13 +1,10 @@
 package org.jbehavesupport.test.support
 
-import com.browserstack.local.Local
 import org.jbehavesupport.test.GenericStory
 
 import java.time.LocalDate
 
 trait TestSupportBrowserStack {
-
-    static Local bsLocal = new Local()
 
     Class runWith(String storyFile) {
         GenericStory.STORY_FILE = "org/jbehavesupport/test/" + storyFile
@@ -16,18 +13,6 @@ trait TestSupportBrowserStack {
 
     String getBuildName() {
         return LocalDate.now().toString()
-    }
-
-    void setupBrowserStackLocal(String key) {
-        if (!bsLocal.isRunning()) {
-            HashMap<String, String> bsLocalArgs = new HashMap<String, String>()
-            bsLocalArgs.put("key", key)
-            bsLocal.start(bsLocalArgs)
-        }
-    }
-
-    void stopBrowserStackLocal() {
-        bsLocal.stop()
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,6 @@
         <version.saaj-impl>1.5.2</version.saaj-impl>
         <version.jakarta.activation>1.2.2</version.jakarta.activation>
         <version.bytebuddy>1.10.17</version.bytebuddy>
-        <version.browserstack-local-java>1.0.6</version.browserstack-local-java>
 
         <plugin.version.maven-javadoc-plugin>3.2.0</plugin.version.maven-javadoc-plugin>
         <plugin.version.maven-failsafe-plugin>2.22.2</plugin.version.maven-failsafe-plugin>
@@ -458,11 +457,6 @@
                 <groupId>com.sun.activation</groupId>
                 <artifactId>jakarta.activation</artifactId>
                 <version>${version.jakarta.activation}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.browserstack</groupId>
-                <artifactId>browserstack-local-java</artifactId>
-                <version>${version.browserstack-local-java}</version>
             </dependency>
             <dependency>
                 <groupId>com.splunk</groupId>


### PR DESCRIPTION
Rewritten BrowserStack tests to expect Local binary already running in the background.

Should significantly stabilize our BrowserStack pipeline. Con: developer is expected to download and run the local binary on his computer when running the BrowserStack tests.