### PR TITLE
Splunk report extension

### DIFF
--- a/jbehave-support-core/docs/Reporting.md
+++ b/jbehave-support-core/docs/Reporting.md
@@ -57,6 +57,9 @@ There are several extensions already prepared and ready to use:
       - CACHE: copies cached server log(s) used within scenario execution
     - Extension contains fail mode, which acts like TEMPLATE mode if test fails
       - it can be turned on by using property: ssh.reporting.logOnFailure with value "true"
+  - `SplunkXmlReporterExtension` (copies Splunk queries and their results from [SplunkSteps](Splunk.md))
+    - Splunk implementation is still under active development and changes can/will be done.
+    - Reporting works with default implementation of `OneShotSearchSplunkClient` provided by us
 
 
 To use these extensions simply register the wanted extension as a bean, e.g.:

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/splunk/SplunkSearchContext.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/splunk/SplunkSearchContext.java
@@ -1,0 +1,14 @@
+package org.jbehavesupport.core.internal.splunk;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.jbehavesupport.core.splunk.SplunkSearchResultEntry;
+
+@AllArgsConstructor
+public class SplunkSearchContext {
+    @Getter
+    private List<SplunkSearchResultEntry> searchResults;
+    @Getter
+    private String query;
+}

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/report/extension/SplunkXmlReporterExtension.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/report/extension/SplunkXmlReporterExtension.java
@@ -1,0 +1,55 @@
+package org.jbehavesupport.core.report.extension;
+
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import org.jbehavesupport.core.report.ReportContext;
+import org.jbehavesupport.core.internal.splunk.SplunkSearchContext;
+import org.jbehavesupport.core.splunk.SplunkSearchResultEntry;
+
+public class SplunkXmlReporterExtension extends AbstractXmlReporterExtension {
+
+    private static final String SPLUNK_XML_REPORTER_EXTENSION = "splunk";
+    private static final String SEARCH_RESULT_TAG = "searchResult";
+    private static final String TIME_TAG = "time";
+    private static final String QUERY_TAG = "query";
+    private static final String MESSAGE_TAG = "message";
+    private static final String RECORD_TAG = "record";
+
+    private final List<SplunkSearchContext> searchResults = new ArrayList<>();
+
+    @Override
+    public String getName() {
+        return SPLUNK_XML_REPORTER_EXTENSION;
+    }
+
+    @Override
+    public void print(Writer writer, ReportContext reportContext) {
+        searchResults.forEach(query -> printSplunkSearchResult(writer, query));
+        searchResults.clear();
+    }
+
+    public void addSplunkSearchContext(SplunkSearchContext splunkSearchContext) {
+        searchResults.add(splunkSearchContext);
+    }
+
+    private void printSplunkSearchResult(Writer writer, SplunkSearchContext splunkSearchContext) {
+        printBegin(writer, SEARCH_RESULT_TAG);
+        printBegin(writer, QUERY_TAG);
+        printCData(writer, splunkSearchContext.getQuery());
+        printEnd(writer, QUERY_TAG);
+
+        for(SplunkSearchResultEntry searchResult : splunkSearchContext.getSearchResults()){
+            printBegin(writer, RECORD_TAG);
+            printBegin(writer, TIME_TAG);
+            printCData(writer, searchResult.getTime());
+            printEnd(writer, TIME_TAG);
+            printBegin(writer, MESSAGE_TAG);
+            printCData(writer, searchResult.getMessage());
+            printEnd(writer, MESSAGE_TAG);
+            printEnd(writer, RECORD_TAG);
+        }
+
+        printEnd(writer, SEARCH_RESULT_TAG);
+    }
+}

--- a/jbehave-support-core/src/main/resources/functions.js
+++ b/jbehave-support-core/src/main/resources/functions.js
@@ -26,6 +26,10 @@ function reportReady() {
         showHideAllInElement('#sql-queries-body');
     });
 
+    $('#expand-all-splunk-queries').click(function () {
+        showHideAllInElement('#splunk-queries-body');
+    });
+
     $('#expand-all-step-screenshots').click(function () {
             showHideAllInElement('#step-screen-shots');
     });

--- a/jbehave-support-core/src/main/resources/report-generator/envelope.xslt
+++ b/jbehave-support-core/src/main/resources/report-generator/envelope.xslt
@@ -140,6 +140,17 @@
                                 </a>
                             </li>
                         </xsl:if>
+                        <xsl:if test="splunk">
+                            <li class="nav-item">
+                                <a class="nav-link">
+                                    <xsl:attribute name="href">
+                                        <xsl:value-of select="concat('#splunk-queries',$storyIndex)"/>
+                                    </xsl:attribute>
+                                    <i class="fa fa-file-text-o" aria-hidden="true"></i>
+                                    Splunk queries
+                                </a>
+                            </li>
+                        </xsl:if>
                     </ul>
                 </nav>
 
@@ -192,6 +203,9 @@
                         <xsl:with-param name="storyIndex" select="$storyIndex"/>
                     </xsl:call-template>
                     <xsl:call-template name="serverLog">
+                        <xsl:with-param name="storyIndex" select="$storyIndex"/>
+                    </xsl:call-template>
+                    <xsl:call-template name="splunk">
                         <xsl:with-param name="storyIndex" select="$storyIndex"/>
                     </xsl:call-template>
                 </main>

--- a/jbehave-support-core/src/main/resources/report-generator/splunkXmlReport.xslt
+++ b/jbehave-support-core/src/main/resources/report-generator/splunkXmlReport.xslt
@@ -1,0 +1,83 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:template name="splunk">
+        <xsl:param name="storyIndex"/>
+        <xsl:for-each select="splunk">
+            <p>
+                <div class="card">
+                    <xsl:attribute name="id">
+                        <xsl:value-of select="concat('splunk-queries',$storyIndex)"/>
+                    </xsl:attribute>
+                    <div class="card-header">
+                        <i class="fa fa-file-text-o" aria-hidden="true"></i>
+                        Splunk queries (<a href="#splunk-queries-body" id="expand-all-splunk-queries">Toggle all queries</a>)
+                        <a href="#splunk-queries-body" data-toggle="collapse" class="float-right">Collapse</a>
+                    </div>
+                    <div id="splunk-queries-body" class="card-body collapse show">
+                        <xsl:choose>
+                            <xsl:when test="searchResult">
+                                <xsl:call-template name="searchResult"/>
+                            </xsl:when>
+                            <xsl:otherwise>No splunk queries available</xsl:otherwise>
+                        </xsl:choose>
+                    </div>
+                </div>
+            </p>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="searchResult">
+        <xsl:for-each select="searchResult">
+            <xsl:variable name="searchResultNum">
+                <xsl:number level="any"/>
+            </xsl:variable>
+
+            <div>
+                <xsl:attribute name="class">
+                    <xsl:if test="not(record)">emptySplunkSearch</xsl:if>
+                </xsl:attribute>
+
+                <a data-toggle="collapse">
+                    <xsl:attribute name="class">
+                        <xsl:choose>
+                            <xsl:when test="record">pointerCursor</xsl:when>
+                            <xsl:otherwise>inactiveLink</xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:attribute>
+
+                    <xsl:if test="record">
+                        <xsl:attribute name="href">
+                            #search-result-<xsl:value-of select="$searchResultNum"/>
+                        </xsl:attribute>
+                        <i class="fa fa-plus-circle" aria-hidden="true"/>
+                    </xsl:if>
+                    <xsl:value-of select="query" disable-output-escaping="yes"/>
+                </a>
+
+                <div id="search-result-{$searchResultNum}" class="collapse">
+                    <xsl:if test="record">
+                        <table class="table table-sm table-hover">
+                            <thead>
+                                <tr>
+                                    <th>Time</th>
+                                    <th>Message</th>
+                                </tr>
+                            </thead>
+                            <xsl:for-each select="record">
+                                <tr>
+                                    <td>
+                                        <xsl:value-of select="time"/>
+                                    </td>
+                                    <td>
+                                        <xsl:value-of select="message"/>
+                                    </td>
+                                </tr>
+                            </xsl:for-each>
+                        </table>>
+                    </xsl:if>
+                </div>
+            </div>
+        </xsl:for-each>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/jbehave-support-core/src/main/resources/report.xslt
+++ b/jbehave-support-core/src/main/resources/report.xslt
@@ -10,6 +10,7 @@
     <xsl:import href="report-generator/failScreenshotReport.xslt"/>
     <xsl:import href="report-generator/screenshotReport.xslt"/>
     <xsl:import href="report-generator/jmsXmlReport.xslt"/>
+    <xsl:import href="report-generator/splunkXmlReport.xslt"/>
 
     <xsl:output method="html" doctype-system="about:legacy-compat"/>
 

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestConfig.java
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestConfig.java
@@ -11,6 +11,7 @@ import org.jbehavesupport.core.TestContext;
 import org.jbehavesupport.core.healthcheck.HealthCheck;
 import org.jbehavesupport.core.healthcheck.HealthChecks;
 import org.jbehavesupport.core.internal.FileNameResolver;
+import org.jbehavesupport.core.report.extension.SplunkXmlReporterExtension;
 import org.jbehavesupport.core.splunk.OneShotSearchSplunkClient;
 import org.jbehavesupport.core.jms.JmsJaxbHandler;
 import org.jbehavesupport.core.report.XmlReporterFactory;
@@ -149,6 +150,11 @@ public class TestConfig {
     @Bean
     public ScreenshotReporterExtension screenshotReporterExtension(TestContext testContext) {
         return new ScreenshotReporterExtension(testContext);
+    }
+
+    @Bean
+    public SplunkXmlReporterExtension splunkXmlReporterExtension(){
+        return new SplunkXmlReporterExtension();
     }
 
     @Bean


### PR DESCRIPTION
New extensions for splunk.
How does it look?
![image](https://user-images.githubusercontent.com/50624143/101384151-5836f000-38ba-11eb-8806-d9dd5d01b0c9.png)

There is more attributes in splunk result entity (level, message ,namespace ,index, host) but I don't see a reason to put them to report extension (namespace and index is going to be part of query most probably and rest isn't interesting).