### PR TITLE
Added JSONPath verification support

### DIFF
--- a/jbehave-support-core/docs/Rest-api.md
+++ b/jbehave-support-core/docs/Rest-api.md
@@ -157,12 +157,12 @@ When [POST] request to [TEST]/[user/] is sent with data:
 (Saving and verifying raw body from response is done in the same way with the `@body` as well, except in these cases other keys can be present as well.)
 
 #### Handling JSON data types
-All JSON data will be send as a string, unless specified otherwise. To specify a data type, use optional `type` column in your data table. These data types are supported:
+All JSON data will be sent as a string, unless specified otherwise. To specify a data type, use optional `type` column in your data table. These data types are supported:
  + `string`
  + `boolean`
  + `number`
 
-If you leave the column blank, the data will be send as a string. The `{NULL}` command will send `null` no matter what is written in the type column.
+If you leave the column blank, the data will be sent as a string. The `{NULL}` command will send `null` no matter what is written in the type column.
 
 Ex.:
 ```
@@ -187,4 +187,12 @@ To enable logging of JSON messages add `RestLoggingInterceptor` into logback
 <logger name="org.jbehavesupport.core.rest.RestLoggingInterceptor" level="trace" additivity="false">
         <appender-ref ref="CONSOLE"/>
 </logger>
+```
+
+#### Verifying using JSONPath
+We offer limited support for JSONPath verification. To use it simply start the value in the `name` column with `$.`, e.g.:
+```
+Then response from [TEST] REST API has status [200] and values match:
+| name                                   | expectedValue    | verifier |
+| $[?(@.firstName=='Bruno')].id          |                  | NOT_NULL |
 ```

--- a/jbehave-support-core/docs/examples/Rest.md
+++ b/jbehave-support-core/docs/examples/Rest.md
@@ -19,7 +19,7 @@ public RestServiceHandler testRestServiceHandler() {
     return new TestRestServiceHandler("http://resttest.com");
 }
 ```
-As a paramter to the constructor, pass the URL of your rest service as a String. (In this case `http://resttest.com`.)
+As a parameter to the constructor, pass the URL of your rest service as a String. (In this case `http://resttest.com`.)
 
 ## Write a [story](../../../README.md#write-your-story)
 Create a Rest.story file with this scenario:

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/rest/RestServiceHandler.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/rest/RestServiceHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONArray;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
@@ -90,6 +91,7 @@ public class RestServiceHandler {
     private static Pattern indexedKeyPattern2 = Pattern.compile("^\\[(\\d+)\\]\\.(.*)");
     private static Pattern indexedKeyPattern3 = Pattern.compile("(.*)\\[(\\d*)\\]");
     private static final String PERIOD_REGEX = "\\.(\\d+)(\\.)?";
+    private static final String JSON_PATH_ROOT = "$";
 
     private String url;
 
@@ -181,7 +183,6 @@ public class RestServiceHandler {
             state(!isRaw, "multipart request can not use raw data");
             return createMultipartRequestEntity(requestDataList, headers);
         } else if (isRaw) {
-
             return createRawBodyRequestEntity(requestDataList, headers);
         }
         return createJsonRequestEntity(requestDataList, headers);
@@ -555,7 +556,12 @@ public class RestServiceHandler {
             return headerValues.get(0);
         }
 
-        return jsonContext.read("$." + propertyName);
+        String jsonPath = propertyName.startsWith(JSON_PATH_ROOT) ? propertyName : JSON_PATH_ROOT + '.' + propertyName;
+        Object propertyValue = jsonContext.read(jsonPath);
+        if (propertyValue instanceof JSONArray && ((JSONArray) propertyValue).size() == 1) {
+            return ((JSONArray) propertyValue).get(0);
+        }
+        return propertyValue;
     }
 
     /**

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Rest.story
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Rest.story
@@ -356,3 +356,14 @@ Then response from [TEST] REST API has status [200]
 When response values from [TEST] REST API are saved:
 | name  | contextAlias |
 | @body | JSON_BODY    |
+
+Scenario: using JSONPath
+When [POST] request to [TEST]/[user/] is sent with data:
+| name                 | data                           | contextAlias |
+| firstName            | Bruno                          |              |
+| lastName             | {RANDOM_STRING:10}             | LAST_NAME    |
+Then response from [TEST] REST API has status [200] and values match:
+| name                                   | expectedValue    | verifier |
+| $[?(@.firstName=='Bruno')].id          |                  | NOT_NULL |
+| $.firstName                            | Bruno            |          |
+| $[?(@.firstName=='Bruno')].lastName    | {CP:LAST_NAME}   |          |


### PR DESCRIPTION
One of possible solutions for #463 (JSONPath part)

Open points:

- Is this limited support (user must always start with `$.` if they want to use JSONPath) enough? Or do we want to do it in some other more complicated way (`@json.path` prefix, new step, or something completely different)?
- Does anyone know why IDEA always escapes the dollar sign and if thats a bug or not? (does not seem to be doing this on GitHub though)

![image](https://user-images.githubusercontent.com/43804753/105079125-46d32d00-5a8f-11eb-84c4-7fe132c3d382.png)
