### PR TITLE
Java upgrade 15->16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 15 ]
+        java: [ 8, 11, 16 ]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.4
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 15 ]
+        java: [ 8, 11, 16 ]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.4
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 15 ]
+        java: [ 8, 11, 16 ]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: System test with Java ${{ matrix.java }}
         run: |
-          xvfb-run mvn org.jacoco:jacoco-maven-plugin:prepare-agent-integration verify org.jacoco:jacoco-maven-plugin:report-integration -DskipUnitTests=true -Djbehave.report.level=STORY -Pintegration-test -B -V
+          xvfb-run mvn org.jacoco:jacoco-maven-plugin:prepare-agent-integration verify org.jacoco:jacoco-maven-plugin:report-integration -DskipUnitTests=true -Djbehave.report.level=STORY -D--add-opens -Djava.base/java.lang=ALL-UNNAMED -Pintegration-test -B -V
       - name: Upload reports on Java ${{ matrix.java }}
         uses: actions/upload-artifact@v2.2.2
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We are happy You are considering contributing to jbehave-support! 😃
 Before you start, please read this short guide, so You don`t get lost. If You have any questions, do not hesitate to ask in GitHub discussions.
 
 ## Dev environment
-This project is written in Java 8, however we are aiming for Java 11 and latest Java compatibility (CI is run against 8, 11 and latest Java - currently 15). 
+This project is written in Java 8, however we are aiming for Java 11 and latest Java compatibility (CI is run against 8, 11 and latest Java - currently 16). 
 
 We are using the latest version of IntelliJ IDEA as an IDE. These are the plugins you need:
 * SonarLint

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ along with support for [verification](jbehave-support-core/docs/General.md#verif
 [expression commands](jbehave-support-core/docs/Expression-commands.md) and 
 basic [reporting](jbehave-support-core/docs/Reporting.md).
 
-Currently supported Java versions are 8, 11 (latest LTS) and 15 (latest version).
+Currently supported Java versions are 8, 11 (latest LTS) and 16 (latest version).
 
 ## Contents
 1. [Modules](#modules)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ along with support for [verification](jbehave-support-core/docs/General.md#verif
 [expression commands](jbehave-support-core/docs/Expression-commands.md) and 
 basic [reporting](jbehave-support-core/docs/Reporting.md).
 
-Currently supported Java versions are 8, 11 (latest LTS) and 16 (latest version).
+Currently supported Java versions are 8, 11 (latest LTS) and 16 (latest version).  
+Java 16 support is limited due to JEP 396 and incompatibilities in some of our dependencies. When running on Java 16 please use `--add-opens java.base/java.lang=ALL-UNNAMED` or `--illegal-access=permit`
+to bypass the newly introduced restrictions in the meantime.
 
 ## Contents
 1. [Modules](#modules)

--- a/jbehave-support-core-test/jbehave-support-core-test-oxm/pom.xml
+++ b/jbehave-support-core-test/jbehave-support-core-test-oxm/pom.xml
@@ -32,36 +32,36 @@
         <plugins>
             <!-- generate java from XSD -->
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-xjc-plugin</artifactId>
+                <configuration>
+                    <extensions>
+                        <extension>net.java.dev.jaxb2-commons:jaxb-fluent-api:2.1.8</extension>
+                    </extensions>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>client</id>
-                        <phase>generate-resources</phase>
+                        <id>generate-sources</id>
+                        <phase>generate-sources</phase>
                         <goals>
-                            <goal>generate</goal>
+                            <goal>xsdtojava</goal>
                         </goals>
                         <configuration>
-                            <schemaDirectory>${project.basedir}/src/main/resources</schemaDirectory>
-                            <extension>true</extension>
-                            <enableIntrospection>true</enableIntrospection>
-                            <bindingDirectory>${project.basedir}/src/main/resources</bindingDirectory>
-                            <bindingIncludes>
-                                <bindingInclude>binding.xjb</bindingInclude>
-                            </bindingIncludes>
-                            <plugins>
-                                <plugin>
-                                    <groupId>net.java.dev.jaxb2-commons</groupId>
-                                    <artifactId>jaxb-fluent-api</artifactId>
-                                    <version>2.1.8</version>
-                                </plugin>
-                            </plugins>
-                            <args>
-                                <arg>-Xfluent-api</arg>
-                            </args>
+                            <sourceRoot>${basedir}/target/generated-sources/cxf/</sourceRoot>
+                            <xsdOptions>
+                                <xsdOption>
+                                    <xsd>${project.basedir}/src/main/resources/name.xsd</xsd>
+                                    <bindingFile>${project.basedir}/src/main/resources/binding.xjb</bindingFile>
+                                    <extension>true</extension>
+                                    <extensionArgs>
+                                        <extensionArg>-Xfluent-api</extensionArg>
+                                    </extensionArgs>
+                                </xsdOption>
+                            </xsdOptions>
                         </configuration>
                     </execution>
                 </executions>
+
             </plugin>
         </plugins>
     </build>

--- a/jbehave-support-core-test/pom.xml
+++ b/jbehave-support-core-test/pom.xml
@@ -33,10 +33,12 @@
         <version.jakarta.mail-api>1.6.5</version.jakarta.mail-api>
         <version.jakarta.xml.soap-api>1.4.2</version.jakarta.xml.soap-api>
         <version.saaj-impl>1.5.2</version.saaj-impl>
-        <plugin.version.maven-jaxb2-plugin>0.14.0</plugin.version.maven-jaxb2-plugin>
+        <plugin.version.cxf-xjc-plugin>3.3.1</plugin.version.cxf-xjc-plugin>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <sonar.skip>true</sonar.skip>
+        <!-- override version from boot parent, remove once boot has same or newer -->
+        <lombok.version>1.18.20</lombok.version>
     </properties>
 
     <dependencyManagement>
@@ -103,9 +105,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.jvnet.jaxb2.maven2</groupId>
-                    <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>${plugin.version.maven-jaxb2-plugin}</version>
+                    <groupId>org.apache.cxf</groupId>
+                    <artifactId>cxf-xjc-plugin</artifactId>
+                    <version>${plugin.version.cxf-xjc-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jbehave-support-core-test/pom.xml
+++ b/jbehave-support-core-test/pom.xml
@@ -39,6 +39,7 @@
         <sonar.skip>true</sonar.skip>
         <!-- override version from boot parent, remove once boot has same or newer -->
         <lombok.version>1.18.20</lombok.version>
+        <groovy.version>3.0.7</groovy.version>
     </properties>
 
     <dependencyManagement>

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/NextCalendarDayCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/temporal/NextCalendarDayCommandTest.groovy
@@ -1,6 +1,5 @@
 package org.jbehavesupport.core.expression.temporal
 
-
 import org.jbehavesupport.core.internal.expression.temporal.NextCalendarDayCommand
 import org.jbehavesupport.core.support.TimeFacade
 import spock.lang.Specification
@@ -12,10 +11,10 @@ import java.time.ZoneId
 @Unroll
 class NextCalendarDayCommandTest extends Specification {
 
-    def toInstant = { year, month, dayOfMonth -> new LocalDate(year, month, dayOfMonth).atStartOfDay().atZone(ZoneId.systemDefault()).toInstant() }
-    def monthWith31daysTimeFacade = [getCurrentInstant: { -> toInstant(2005, 5, 20) }] as TimeFacade
-    def monthWith30daysTimeFacade = [getCurrentInstant: { -> toInstant(2005, 4, 20) }] as TimeFacade
-    def monthWith28daysTimeFacade = [getCurrentInstant: { -> toInstant(2005, 2, 20) }] as TimeFacade
+    def toInstant = { year, month, dayOfMonth -> LocalDate.of(year, month, dayOfMonth).atStartOfDay().atZone(ZoneId.systemDefault()).toInstant() }
+    def monthWith31daysTimeFacade = [getCurrentDate: { -> Date.from(toInstant(2005, 5, 20))}] as TimeFacade
+    def monthWith30daysTimeFacade = [getCurrentDate: { -> Date.from(toInstant(2005, 4, 20))}] as TimeFacade
+    def monthWith28daysTimeFacade = [getCurrentDate: { -> Date.from(toInstant(2005, 2, 20))}] as TimeFacade
 
     def "for a 31 days long month test execute with #expression returns #expected"() {
         when:

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/TestContextImplTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/TestContextImplTest.groovy
@@ -11,8 +11,8 @@ class TestContextImplTest extends Specification {
     def "Get values with type #key and expected #expected"() {
         setup:
         TestContext tc = new TestContextImpl()
-        tc.put("myLong", new Long(7))
-        tc.put("myBigInt", new BigInteger(8))
+        tc.put("myLong", 7L)
+        tc.put("myBigInt", 8G)
         tc.put("myBigDec", new BigDecimal("9"))
         tc.put("stLong", "22")
         tc.put("stBigInt", "33")
@@ -27,7 +27,7 @@ class TestContextImplTest extends Specification {
         where:
         key        | expected
         "myLong"   | Long.valueOf(7)
-        "myBigInt" | new BigInteger(8)
+        "myBigInt" | BigInteger.valueOf(8)
         "myBigDec" | new BigDecimal(9)
         "stLong"   | "22"
         "stBigInt" | "33"

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/EqualsVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/EqualsVerifierTest.groovy
@@ -32,7 +32,7 @@ class EqualsVerifierTest extends Specification {
         ""                         | ""
         null                       | null
         "tst"                      | "tst"
-        new LocalDate(2002, 7, 14) | new LocalDate(2002, 7, 14)
+        LocalDate.of(2002, 7, 14)  | LocalDate.of(2002, 7, 14)
         12                         | 12
         [1,2,3,4] as int[]         | [1,2,3,4] as int[]
     }
@@ -48,7 +48,7 @@ class EqualsVerifierTest extends Specification {
 
         where:
         actual                     | expected                   || message
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 14) || "value '2002-07-15' is not equal to '2002-07-14'"
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 14)  || "value '2002-07-15' is not equal to '2002-07-14'"
         7                          | 9                          || "value '7' is not equal to '9'"
         "me"                       | "you"                      || "value 'me' is not equal to 'you'"
         null                       | "we"                       || "Actual value must be provided"

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/GreaterThanOrEqualVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/GreaterThanOrEqualVerifierTest.groovy
@@ -33,9 +33,9 @@ class GreaterThanOrEqualVerifierTest extends Specification {
         20                         | 7
         20                         | 20
         456.789                    | 132.456
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 14)
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 15)
-        new LocalDate(2002, 7, 15) | "2000-06-14"
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 14)
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 15)
+        LocalDate.of(2002, 7, 15)  | "2000-06-14"
     }
 
     @Unroll
@@ -51,7 +51,7 @@ class GreaterThanOrEqualVerifierTest extends Specification {
         actual                     | expected                   || message
         7                          | 22                         || "value '7' is not greater than or equal to '22'"
         1.000001                   | 2.000002                   || "value '1.000001' is not greater than or equal to '2.000002'"
-        new LocalDate(2002, 7, 15) | "2003-01-01"               || "value '2002-07-15' is not greater than or equal to '2003-01-01'"
+        LocalDate.of(2002, 7, 15)  | "2003-01-01"               || "value '2002-07-15' is not greater than or equal to '2003-01-01'"
     }
 
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/GreaterThanVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/GreaterThanVerifierTest.groovy
@@ -32,8 +32,8 @@ class GreaterThanVerifierTest extends Specification {
         actual                     | expected
         20                         | 7
         456.789                    | 132.456
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 14)
-        new LocalDate(2002, 7, 15) | "2000-06-14"
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 14)
+        LocalDate.of(2002, 7, 15)  | "2000-06-14"
     }
 
 
@@ -51,7 +51,7 @@ class GreaterThanVerifierTest extends Specification {
         7                          | 22                         || "value '7' is not greater than '22'"
         7                          | 7                          || "value '7' is not greater than '7'"
         1.000001                   | 2.000002                   || "value '1.000001' is not greater than '2.000002'"
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 15) || "value '2002-07-15' is not greater than '2002-07-15'"
-        new LocalDate(2002, 7, 15) | "2003-01-01"               || "value '2002-07-15' is not greater than '2003-01-01'"
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 15)  || "value '2002-07-15' is not greater than '2002-07-15'"
+        LocalDate.of(2002, 7, 15)  | "2003-01-01"               || "value '2002-07-15' is not greater than '2003-01-01'"
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/LowerThanOrEqualVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/LowerThanOrEqualVerifierTest.groovy
@@ -32,9 +32,9 @@ class LowerThanOrEqualVerifierTest extends Specification {
         9                          | 13
         22                         | 22
         3.88                       | 4.11
-        new LocalDate(2002, 7, 14) | new LocalDate(2002, 7, 15)
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 15)
-        new LocalDate(2002, 7, 14) | "2002-08-14"
+        LocalDate.of(2002, 7, 14)  | LocalDate.of(2002, 7, 15)
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 15)
+        LocalDate.of(2002, 7, 14)  | "2002-08-14"
     }
 
     @Unroll
@@ -50,7 +50,7 @@ class LowerThanOrEqualVerifierTest extends Specification {
         actual                     | expected                   || message
         22                         | 7                          || "value '22' is not lower than or equal to '7'"
         100000.1                   | 0.000001                   || "value '100000.1' is not lower than or equal to '0.000001'"
-        new LocalDate(2002, 7, 15) | "2000-01-01"               || "value '2002-07-15' is not lower than or equal to '2000-01-01'"
+        LocalDate.of(2002, 7, 15)  | "2000-01-01"               || "value '2002-07-15' is not lower than or equal to '2000-01-01'"
     }
 
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/LowerThanVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/LowerThanVerifierTest.groovy
@@ -31,8 +31,8 @@ class LowerThanVerifierTest extends Specification {
         actual                     | expected
         9                          | 13
         3.88                       | 4.11
-        new LocalDate(2002, 7, 14) | new LocalDate(2002, 7, 15)
-        new LocalDate(2002, 7, 14) | "2002-08-14"
+        LocalDate.of(2002, 7, 14)  | LocalDate.of(2002, 7, 15)
+        LocalDate.of(2002, 7, 14)  | "2002-08-14"
     }
 
     @Unroll
@@ -49,7 +49,7 @@ class LowerThanVerifierTest extends Specification {
         22                         | 7                          || "value '22' is not lower than '7'"
         22                         | 22                         || "value '22' is not lower than '22'"
         100000.1                   | 0.000001                   || "value '100000.1' is not lower than '0.000001'"
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 15) || "value '2002-07-15' is not lower than '2002-07-15'"
-        new LocalDate(2002, 7, 15) | "2000-01-01"               || "value '2002-07-15' is not lower than '2000-01-01'"
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 15) || "value '2002-07-15' is not lower than '2002-07-15'"
+        LocalDate.of(2002, 7, 15)  | "2000-01-01"               || "value '2002-07-15' is not lower than '2000-01-01'"
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/NotEqualsVerifierTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/internal/verification/NotEqualsVerifierTest.groovy
@@ -29,7 +29,7 @@ class NotEqualsVerifierTest extends Specification {
 
         where:
         actual                     | expected
-        new LocalDate(2002, 7, 15) | new LocalDate(2002, 7, 14)
+        LocalDate.of(2002, 7, 15)  | LocalDate.of(2002, 7, 14)
         7                          | 9
         "me"                       | "you"
         [1,2,3,4] as int[]         | [4,3,2,1] as int[]
@@ -49,7 +49,7 @@ class NotEqualsVerifierTest extends Specification {
         ""                         | ""                         || "'' must be different from ''"
         null                       | null                       || "'null' must be different from 'null'"
         "tst"                      | "tst"                      || "'tst' must be different from 'tst'"
-        new LocalDate(2002, 7, 14) | new LocalDate(2002, 7, 14) || "'2002-07-14' must be different from '2002-07-14'"
+        LocalDate.of(2002, 7, 14)  | LocalDate.of(2002, 7, 14)  || "'2002-07-14' must be different from '2002-07-14'"
         null                       | "asd"                      || "Actual value must be provided"
         [1,2,3,4] as int[]         | [1,2,3,4] as int[]         || "must be different from"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <version.java.release>1.8</version.java.release>
 
         <version.jbehave>4.8.3</version.jbehave>
-        <version.lombok>1.18.18</version.lombok>
+        <version.lombok>1.18.20</version.lombok>
         <version.jbehave-junit-support>4.8.3</version.jbehave-junit-support>
         <version.groovy>3.0.7</version.groovy>
         <version.junit>4.13.2</version.junit>


### PR DESCRIPTION
So far the build fails because of old (and it seems unmaintained) jaxb plugin used in tests to generate java classes from xsd.

We should decide what to do with that - one option is to migrate to maintained and developed: https://github.com/mojohaus/jaxb2-maven-plugin

Or maybe even: http://cxf.apache.org/cxf-xjc-plugin.html