### PR TITLE
Improved BigDecimal conversions in arithmetic commands, fixed wrong r…

### DIFF
--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/DivideCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/DivideCommand.java
@@ -4,8 +4,11 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.Arrays;
+
+import lombok.RequiredArgsConstructor;
 import org.jbehavesupport.core.expression.ExpressionCommand;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
 import static org.jbehavesupport.core.internal.expression.CommandHelper.checkNumericParams;
 import static org.springframework.util.Assert.isTrue;
@@ -15,7 +18,10 @@ import static org.springframework.util.Assert.isTrue;
  * parameters goes in order: dividend, divisors...
  */
 @Component
+@RequiredArgsConstructor
 public class DivideCommand implements ExpressionCommand {
+
+    private final ConversionService conversionService;
 
     @Value("${numeric.scale:10}")
     private int scale = 10;
@@ -25,13 +31,16 @@ public class DivideCommand implements ExpressionCommand {
         isTrue(params.length >= 2, "At least two parameters were expected");
         checkNumericParams(params);
 
-        BigDecimal[] divisors = Arrays.stream(params).skip(1).map( it -> new BigDecimal(it.toString())).toArray(BigDecimal[]::new);
+        BigDecimal[] divisors = Arrays.stream(params)
+            .skip(1)
+            .map(it -> conversionService.convert(it, BigDecimal.class))
+            .toArray(BigDecimal[]::new);
 
         if (Arrays.asList(divisors).contains(BigDecimal.ZERO)){
             throw new IllegalArgumentException("Can not divide by zero");
         }
 
         return Arrays.stream(divisors)
-            .reduce(new BigDecimal(params[0].toString()), (dividend, divisor) -> dividend.divide(divisor, new MathContext(scale, RoundingMode.HALF_UP)));
+            .reduce(conversionService.convert(params[0], BigDecimal.class), (dividend, divisor) -> dividend.divide(divisor, new MathContext(scale, RoundingMode.HALF_UP)));
     }
 }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/MinusCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/MinusCommand.java
@@ -2,7 +2,10 @@ package org.jbehavesupport.core.internal.expression.numeric;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+
+import lombok.RequiredArgsConstructor;
 import org.jbehavesupport.core.expression.ExpressionCommand;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
 import static org.jbehavesupport.core.internal.expression.CommandHelper.checkNumericParams;
 import static org.springframework.util.Assert.isTrue;
@@ -12,7 +15,10 @@ import static org.springframework.util.Assert.isTrue;
  * Parameters must be numbers or numeric string.
  */
 @Component
+@RequiredArgsConstructor
 public class MinusCommand implements ExpressionCommand {
+
+    private final ConversionService conversionService;
 
     @Override
     public Object execute(Object... params) {
@@ -20,7 +26,7 @@ public class MinusCommand implements ExpressionCommand {
         checkNumericParams(params);
         return Arrays
             .stream(Arrays.copyOfRange(params, 1, params.length))
-            .map(i -> new BigDecimal(i.toString()))
-            .reduce(new BigDecimal(params[0].toString()), BigDecimal::subtract);
+            .map(i -> conversionService.convert(i, BigDecimal.class))
+            .reduce(conversionService.convert(params[0], BigDecimal.class), BigDecimal::subtract);
     }
 }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/MultiplyCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/MultiplyCommand.java
@@ -2,7 +2,10 @@ package org.jbehavesupport.core.internal.expression.numeric;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+
+import lombok.RequiredArgsConstructor;
 import org.jbehavesupport.core.expression.ExpressionCommand;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
 import static org.jbehavesupport.core.internal.expression.CommandHelper.checkNumericParams;
 import static org.springframework.util.Assert.isTrue;
@@ -12,14 +15,17 @@ import static org.springframework.util.Assert.isTrue;
  * Parameters must be numbers or numeric string.
  */
 @Component
+@RequiredArgsConstructor
 public class MultiplyCommand implements ExpressionCommand {
+
+    private final ConversionService conversionService;
 
     @Override
     public Object execute(Object... params) {
         isTrue(params.length >= 2, "At least two parameters were expected");
         checkNumericParams(params);
         return Arrays.stream(params)
-            .map(i -> new BigDecimal(i.toString()))
+            .map(i -> conversionService.convert(i, BigDecimal.class))
             .reduce(BigDecimal.ONE, BigDecimal::multiply);
     }
 }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/PlusCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/PlusCommand.java
@@ -4,7 +4,10 @@ import static org.jbehavesupport.core.internal.expression.CommandHelper.checkNum
 import static org.springframework.util.Assert.isTrue;
 import java.math.BigDecimal;
 import java.util.Arrays;
+
+import lombok.RequiredArgsConstructor;
 import org.jbehavesupport.core.expression.ExpressionCommand;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
 
 /**
@@ -12,14 +15,17 @@ import org.springframework.stereotype.Component;
  * Parameters must be numbers or numeric string.
  */
 @Component
+@RequiredArgsConstructor
 public class PlusCommand implements ExpressionCommand {
+
+    private final ConversionService conversionService;
 
     @Override
     public Object execute(Object... params) {
         isTrue(params.length >= 2, "At least two parameters were expected");
         checkNumericParams(params);
         return Arrays.stream(params)
-            .map(i -> new BigDecimal(i.toString()))
+            .map(i -> conversionService.convert(i, BigDecimal.class))
             .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 }

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/RoundCommand.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/internal/expression/numeric/RoundCommand.java
@@ -3,7 +3,10 @@ package org.jbehavesupport.core.internal.expression.numeric;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+
+import lombok.RequiredArgsConstructor;
 import org.jbehavesupport.core.expression.ExpressionCommand;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
 import static org.jbehavesupport.core.internal.expression.CommandHelper.checkNumericParams;
 import static org.springframework.util.Assert.isTrue;
@@ -13,19 +16,24 @@ import static org.springframework.util.Assert.isTrue;
  * parameters goes in order: number, decimal places
  */
 @Component
+@RequiredArgsConstructor
 public class RoundCommand implements ExpressionCommand {
+
+    private final ConversionService conversionService;
 
     @Override
     public Object execute(Object... params) {
         isTrue(params.length == 2, "Two parameters were expected");
         checkNumericParams(params);
-        int scale;
+        int decimalPoints;
         try{
-            scale = Integer.parseInt(params[1].toString());
+            decimalPoints = Integer.parseInt(params[1].toString());
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Scale must be integer");
         }
 
-        return new BigDecimal(params[0].toString()).round(new MathContext(scale + 1, RoundingMode.HALF_UP));
+        BigDecimal number = conversionService.convert(params[0], BigDecimal.class);
+        int scaleBeforeDecimalPoint = number.precision() - number.scale();
+        return number.round(new MathContext(scaleBeforeDecimalPoint + decimalPoints, RoundingMode.HALF_UP));
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/DivideCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/DivideCommandTest.groovy
@@ -1,15 +1,18 @@
 package org.jbehavesupport.core.expression.numeric
 
 import org.jbehavesupport.core.internal.expression.numeric.DivideCommand
+import org.springframework.core.convert.support.DefaultConversionService
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
 class DivideCommandTest extends Specification {
 
+    def conversionService = new DefaultConversionService()
+
     def "Divide command evaluation for #params wit result #expected"() {
         when:
-        def actual = new DivideCommand().execute(*params)
+        def actual = new DivideCommand(conversionService).execute(*params)
         then:
         expected == actual
         where:
@@ -27,7 +30,7 @@ class DivideCommandTest extends Specification {
     @Unroll
     def "Test wrong number of params for DivideCommand"() {
         when:
-        new DivideCommand().execute([1])
+        new DivideCommand(conversionService).execute([1])
 
         then:
         Exception exception = thrown()
@@ -38,7 +41,7 @@ class DivideCommandTest extends Specification {
     @Unroll
     def "Test dividing by zero"() {
         when:
-        new DivideCommand().execute([1, 0, 1].toArray())
+        new DivideCommand(conversionService).execute([1, 0, 1].toArray())
 
         then:
         Exception exception = thrown()

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/MinusCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/MinusCommandTest.groovy
@@ -1,15 +1,18 @@
 package org.jbehavesupport.core.expression.numeric
 
 import org.jbehavesupport.core.internal.expression.numeric.MinusCommand
+import org.springframework.core.convert.support.DefaultConversionService
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
 class MinusCommandTest extends Specification {
 
+    def conversionService = new DefaultConversionService()
+
     def "Minus command evaluation for #params wit result #expected"() {
         when:
-        def actual = new MinusCommand().execute(*params)
+        def actual = new MinusCommand(conversionService).execute(*params)
         then:
         expected == actual
         where:
@@ -25,7 +28,7 @@ class MinusCommandTest extends Specification {
     @Unroll
     def "Test wrong number of params for MinusCommand"() {
         when:
-        new MinusCommand().execute([1])
+        new MinusCommand(conversionService).execute([1])
 
         then:
         Exception exception = thrown()

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/MultiplyCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/MultiplyCommandTest.groovy
@@ -1,15 +1,18 @@
 package org.jbehavesupport.core.expression.numeric
 
 import org.jbehavesupport.core.internal.expression.numeric.MultiplyCommand
+import org.springframework.core.convert.support.DefaultConversionService
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
 class MultiplyCommandTest extends Specification {
 
+    def conversionService = new DefaultConversionService()
+
     def "Multiply command evaluation for #params wit result #expected"() {
         when:
-        def actual = new MultiplyCommand().execute(*params)
+        def actual = new MultiplyCommand(conversionService).execute(*params)
         then:
         expected == actual
         where:
@@ -25,7 +28,7 @@ class MultiplyCommandTest extends Specification {
     @Unroll
     def "Test wrong number of params for MultiplyCommand"() {
         when:
-        new MultiplyCommand().execute([1])
+        new MultiplyCommand(conversionService).execute([1])
 
         then:
         Exception exception = thrown()

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/PlusCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/PlusCommandTest.groovy
@@ -1,15 +1,18 @@
 package org.jbehavesupport.core.expression.numeric
 
 import org.jbehavesupport.core.internal.expression.numeric.PlusCommand
+import org.springframework.core.convert.support.DefaultConversionService
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
 class PlusCommandTest extends Specification {
 
+    def conversionService = new DefaultConversionService()
+
     def "Plus command evaluation for #params wit result #expected"() {
         when:
-        def actual = new PlusCommand().execute(*params)
+        def actual = new PlusCommand(conversionService).execute(*params)
         then:
         expected == actual
         where:
@@ -25,7 +28,7 @@ class PlusCommandTest extends Specification {
     @Unroll
     def "Test wrong number of params for PlusCommand"() {
         when:
-        new PlusCommand().execute([1])
+        new PlusCommand(conversionService).execute([1])
 
         then:
         Exception exception = thrown()

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/RoundCommandTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/expression/numeric/RoundCommandTest.groovy
@@ -1,15 +1,18 @@
 package org.jbehavesupport.core.expression.numeric
 
 import org.jbehavesupport.core.internal.expression.numeric.RoundCommand
+import org.springframework.core.convert.support.DefaultConversionService
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
 class RoundCommandTest extends Specification {
 
+    def conversionService = new DefaultConversionService()
+
     def "Round command evaluation for #params wit result #expected"() {
         when:
-        def actual = new RoundCommand().execute(*params)
+        def actual = new RoundCommand(conversionService).execute(*params)
         then:
         expected == actual
         where:
@@ -19,12 +22,13 @@ class RoundCommandTest extends Specification {
         ["1.1111111111", "10"] || new BigDecimal("1.1111111111")
         [3.3F, 1]              || new BigDecimal("3.3")
         [6.6D, 1]              || new BigDecimal("6.6")
+        ["111.111111111", "1"] || new BigDecimal("111.1")
     }
 
     @Unroll
     def "Test wrong number of params for DivideCommand"() {
         when:
-        new RoundCommand().execute([1])
+        new RoundCommand(conversionService).execute([1])
 
         then:
         Exception exception = thrown()
@@ -35,7 +39,7 @@ class RoundCommandTest extends Specification {
     @Unroll
     def "Test wrong format of scale parameter"() {
         when:
-        new RoundCommand().execute([1, 1.5].toArray())
+        new RoundCommand(conversionService).execute([1, 1.5].toArray())
 
         then:
         Exception exception = thrown()


### PR DESCRIPTION
Improved BigDecimal conversions in arithmetic commands, fixed wrong rounding for bigger numbers (with more than 1 place before decimal point).

Fixes #638 (at least the big number part, report representation will still be toString on BigDecimal which can give "weird" stuff)