### PR TITLE
Cleanup unused (with typo) javadoc config

### DIFF
--- a/jbehave-support-core/pom.xml
+++ b/jbehave-support-core/pom.xml
@@ -181,13 +181,6 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
                             <additionalparam>-Xdoclint:none</additionalparam>
-                            <additionnalDependencies>
-                                <additionalDependency>
-                                    <groupId>jakarta.interceptor</groupId>
-                                    <artifactId>jakarta.interceptor-api</artifactId>
-                                    <version>1.2.5</version>
-                                </additionalDependency>
-                            </additionnalDependencies>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
There was a typo additio**n**nalDependencies (double n) vs additionalDependencies so the config was not used.