### PR TITLE
Migrate to JUnit5

### DIFF
--- a/jbehave-support-core/pom.xml
+++ b/jbehave-support-core/pom.xml
@@ -238,10 +238,16 @@
             <artifactId>spock-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Spock depends on JUnit 5, so we need to supply vintage for JUnit4 tests to run -->
+        <!-- for our junit 5 standard tests -->
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- for launching junit5 tests programmatically - e.g. for running stories out of spock/junit tests -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/AbstractSpringStories.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/AbstractSpringStories.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jbehavesupport.core.internal.FullScenarioNameStorer;
@@ -27,7 +26,6 @@ import org.jbehave.core.failures.FailingUponPendingStep;
 import org.jbehave.core.failures.RethrowingFailure;
 import org.jbehave.core.io.CodeLocations;
 import org.jbehave.core.io.LoadFromClasspath;
-import org.jbehave.core.junit.JUnitStories;
 import org.jbehave.core.model.Meta;
 import org.jbehave.core.parsers.StoryParser;
 import org.jbehave.core.reporters.FilePrintStreamFactory;
@@ -37,9 +35,8 @@ import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.ParameterControls;
 import org.jbehave.core.steps.ParameterConverters;
 import org.jbehave.core.steps.spring.SpringStepsFactory;
-import org.jbehavesupport.runner.JUnitRunner;
-import org.jbehavesupport.runner.JUnitRunnerConfiguration;
-import org.junit.runner.RunWith;
+import org.jbehavesupport.engine.EmbedderConfiguration;
+import org.jbehavesupport.engine.JUnit5Stories;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.ClassPathResource;
@@ -48,9 +45,8 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestContextManager;
 
-@RunWith(JUnitRunner.class)
 @ContextConfiguration(classes = JBehaveDefaultConfig.class)
-public abstract class AbstractSpringStories extends JUnitStories {
+public abstract class AbstractSpringStories extends JUnit5Stories {
 
     public static final String JBEHAVE_SCENARIO = "jbehave_scenario";
 
@@ -121,7 +117,7 @@ public abstract class AbstractSpringStories extends JUnitStories {
         Embedder embedder = super.configuredEmbedder();
         embedder.useMetaFilters(Collections.singletonList(CUSTOM_MATCHER));
         embedder.useMetaMatchers(metaMatchers());
-        JUnitRunnerConfiguration.recommendedConfiguration(embedder).useStoryTimeouts(timeout.toString());
+        EmbedderConfiguration.recommendedConfiguration(embedder).useStoryTimeouts(timeout.toString());
         return embedder;
     }
 
@@ -172,15 +168,15 @@ public abstract class AbstractSpringStories extends JUnitStories {
             return loadResources(path, storyName)
                 .filter(Resource::isReadable)
                 .map(r -> getPath(path, r))
-                .collect(Collectors.toList());
+                .toList();
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
     }
 
     private String getPath(String path, Resource resource) {
-        if (resource instanceof ClassPathResource) {
-            return ((ClassPathResource) resource).getPath();
+        if (resource instanceof ClassPathResource classPathResource) {
+            return classPathResource.getPath();
         } else {
             try {
                 String fullPathWithSlashes = resource.getFile().getPath().replace("\\", "/");

--- a/jbehave-support-core/src/main/java/org/jbehavesupport/core/ssh/SshTemplate.java
+++ b/jbehave-support-core/src/main/java/org/jbehavesupport/core/ssh/SshTemplate.java
@@ -112,7 +112,7 @@ public class SshTemplate {
     }
 
     private SSHClient getSshClient() throws IOException {
-        if (sshClient == null || !sshClient.isConnected()) {
+        if (sshClient == null || !sshClient.isConnected() || !sshClient.isAuthenticated()) {
             sshClient = new SSHClient();
             sshClient.addHostKeyVerifier(new PromiscuousVerifier());
             sshClient.connect(sshSetting.getHostname(), sshSetting.getPort());

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackChromeT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackChromeT.groovy
@@ -1,11 +1,9 @@
 package org.jbehavesupport.core
 
 import org.jbehavesupport.test.support.TestSupportBrowserStack
-import org.junit.runner.JUnitCore
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.test.context.ContextConfiguration
-import spock.lang.Shared
 import spock.lang.Specification
 
 import static org.jbehavesupport.test.support.TestConfig.CHROME_BROWSERSTACK
@@ -20,9 +18,6 @@ class BrowserStackChromeT extends Specification implements TestSupportBrowserSta
     @Autowired
     private Environment env
 
-    @Shared
-    runner = new JUnitCore()
-
     def setup() {
         System.setProperty("web.browser", CHROME_BROWSERSTACK)
         System.setProperty("browser-stack.build", getBuildName())
@@ -31,10 +26,10 @@ class BrowserStackChromeT extends Specification implements TestSupportBrowserSta
     def "Chrome test #story"() {
         when:
         System.setProperty("browser-stack.name", "Chrome test " + story)
-        def result = runner.run(runWith(story))
+        def result = run(runWith(story))
 
         then:
-        result.failureCount == 0
+        result.totalFailureCount == 0
 
         where:
         story                             | _

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackFirefoxT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackFirefoxT.groovy
@@ -1,11 +1,9 @@
 package org.jbehavesupport.core
 
 import org.jbehavesupport.test.support.TestSupportBrowserStack
-import org.junit.runner.JUnitCore
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.test.context.ContextConfiguration
-import spock.lang.Shared
 import spock.lang.Specification
 
 import static org.jbehavesupport.test.support.TestConfig.FIREFOX_BROWSERSTACK
@@ -20,9 +18,6 @@ class BrowserStackFirefoxT extends Specification implements TestSupportBrowserSt
     @Autowired
     private Environment env
 
-    @Shared
-    runner = new JUnitCore()
-
     def setup() {
         System.setProperty("web.browser", FIREFOX_BROWSERSTACK)
         System.setProperty("browser-stack.build", getBuildName())
@@ -31,10 +26,10 @@ class BrowserStackFirefoxT extends Specification implements TestSupportBrowserSt
     def "Firefox test #story"() {
         when:
         System.setProperty("browser-stack.name", "Firefox test " + story)
-        def result = runner.run(runWith(story))
+        def result = run(runWith(story))
 
         then:
-        result.failureCount == 0
+        result.totalFailureCount == 0
 
         where:
         story                             | _

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackSafariT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/BrowserStackSafariT.groovy
@@ -1,12 +1,9 @@
 package org.jbehavesupport.core
 
-import org.jbehavesupport.core.TestConfig
 import org.jbehavesupport.test.support.TestSupportBrowserStack
-import org.junit.runner.JUnitCore
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.test.context.ContextConfiguration
-import spock.lang.Shared
 import spock.lang.Specification
 
 import static org.jbehavesupport.test.support.TestConfig.SAFARI_BROWSERSTACK
@@ -21,9 +18,6 @@ class BrowserStackSafariT extends Specification implements TestSupportBrowserSta
     @Autowired
     private Environment env
 
-    @Shared
-    runner = new JUnitCore()
-
     def setup() {
         System.setProperty("web.browser", SAFARI_BROWSERSTACK)
         System.setProperty("web.url", "http://bs-local.com:11110/")
@@ -33,10 +27,10 @@ class BrowserStackSafariT extends Specification implements TestSupportBrowserSta
     def "Safari test #story"() {
         when:
         System.setProperty("browser-stack.name", "Safari test " + story)
-        def result = runner.run(runWith(story))
+        def result = run(runWith(story))
 
         then:
-        result.failureCount == 0
+        result.totalFailureCount == 0
 
         where:
         story | _

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/RequestFactoryTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/RequestFactoryTest.groovy
@@ -7,29 +7,33 @@ import org.jbehavesupport.core.internal.parameterconverters.ExamplesEvaluationTa
 import org.jbehavesupport.core.support.RequestFactory
 import org.jbehavesupport.core.test.app.oxm.NameRequest
 import org.jbehavesupport.core.ws.WebServiceSteps
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.convert.converter.Converter
 import org.springframework.core.convert.support.ConfigurableConversionService
 import org.springframework.core.convert.support.DefaultConversionService
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
 import jakarta.activation.DataHandler
 import jakarta.xml.bind.JAXBElement
 import javax.xml.datatype.DatatypeConstants
 import javax.xml.datatype.DatatypeFactory
 import javax.xml.datatype.XMLGregorianCalendar
-import java.time.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
 import java.util.function.Consumer
 
 import static groovy.test.GroovyAssert.shouldFail
 import static groovy.test.GroovyAssert.shouldFailWithCause
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig)
 class RequestFactoryTest {
 
@@ -45,7 +49,7 @@ class RequestFactoryTest {
     @Autowired
     WebServiceSteps webServiceSteps
 
-    @Before
+    @BeforeEach
     void init() {
         ctx.clear()
     }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/context/TestContextIT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/context/TestContextIT.groovy
@@ -1,19 +1,14 @@
 package org.jbehavesupport.core.context
 
-import org.junit.runner.JUnitCore
-import spock.lang.Shared
 import spock.lang.Specification
 
 import org.jbehavesupport.test.support.TestSupport
 
 class TestContextIT extends Specification implements TestSupport {
 
-    @Shared
-        runner = new JUnitCore()
-
     def "Test failing context"() {
         when:
-        def result = runner.run(runWith("context/DataNotInContext.story"))
+        def result = run(runWith("context/DataNotInContext.story"))
 
         then:
         result.failures.stream().anyMatch({ e -> e.exception.message.contains("Context must contains [test dat] under key [TEST_DATA]") })
@@ -21,7 +16,7 @@ class TestContextIT extends Specification implements TestSupport {
 
     def "Test typo in context data copy"() {
         when:
-        def result = runner.run(runWith("context/TypoInCopyContextData.story"))
+        def result = run(runWith("context/TypoInCopyContextData.story"))
 
         then:
         result.failures.stream().anyMatch({ e -> e.exception.message.contains("Test context doesn't contain key: TTEST_DATA_FOR_CP") })
@@ -29,17 +24,17 @@ class TestContextIT extends Specification implements TestSupport {
 
     def "Test context"() {
         when:
-        def result = runner.run(runWith("context/Context.story"))
+        def result = run(runWith("context/Context.story"))
 
         then:
-        result.failureCount == 0
+        result.totalFailureCount == 0
     }
 
     def "Clear test context before each scenario"() {
         when:
-        def result = runner.run(runWith("context/ImplicitContextClearing.story"))
+        def result = run(runWith("context/ImplicitContextClearing.story"))
 
         then:
-        result.failureCount == 0
+        result.totalFailureCount == 0
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/filtering/GroovyFilteringTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/filtering/GroovyFilteringTest.groovy
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.StringUtils
 import org.jbehave.core.embedder.MetaFilter
 import org.jbehave.core.model.Story
 import org.jbehavesupport.core.parsers.FilteringStoryParser
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.springframework.core.io.ClassPathResource
 
 /**

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/healthcheck/HealthCheckStepsTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/healthcheck/HealthCheckStepsTest.groovy
@@ -1,9 +1,8 @@
 package org.jbehavesupport.core.healthcheck
 
-
+import org.assertj.core.error.AssertJMultipleFailuresError
 import org.jbehave.core.model.ExamplesTable
 import org.jbehavesupport.core.TestConfig
-import org.junit.runners.model.MultipleFailureException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
@@ -31,7 +30,7 @@ class HealthCheckStepsTest extends Specification {
         ExamplesTable examplesTable = new ExamplesTable(
                 "| component | \n" +
                 "| SICK      |")
-        MultipleFailureException fail = shouldFail(MultipleFailureException.class) {
+        AssertJMultipleFailuresError fail = shouldFail(AssertJMultipleFailuresError.class) {
             healthCheckSteps.checkComponentsAreHealthy(examplesTable)
         }
 

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/report/XmlReportIT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/report/XmlReportIT.groovy
@@ -2,18 +2,14 @@ package org.jbehavesupport.core.report
 
 import groovy.xml.XmlSlurper
 import org.apache.commons.io.FileUtils
-import org.jbehavesupport.core.report.XmlReporterFactory
 import org.jbehavesupport.test.GenericStory
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
 import org.springframework.test.context.TestContextManager
-import spock.lang.Shared
 import spock.lang.Specification
 
 import java.nio.file.Files
 
 class XmlReportIT extends Specification implements TestSupport {
-    @Shared runner = new JUnitCore()
 
     def "Test report index generation"() {
         setup:
@@ -24,10 +20,8 @@ class XmlReportIT extends Specification implements TestSupport {
         } else {
             Files.createDirectory(reportDirectory.toPath())
         }
-        def testContextManager = new TestContextManager(GenericStory)
-        testContextManager.prepareTestInstance(runner)
 
-        def xmlReporterFactory = testContextManager.getTestContext()
+        def xmlReporterFactory = new TestContextManager(GenericStory).getTestContext()
             .applicationContext
             .autowireCapableBeanFactory
             .getBean(XmlReporterFactory)
@@ -36,8 +30,8 @@ class XmlReportIT extends Specification implements TestSupport {
         xmlReporterFactory."$reportsDirectoryField" = reportDir
 
         when:
-        def resultSampleContext = runner.run(runWith("report/SampleContext.story"))
-        def resultContext = runner.run(runWith("context/Context.story"))
+        def resultSampleContext = run(runWith("report/SampleContext.story"))
+        def resultContext = run(runWith("context/Context.story"))
 
         xmlReporterFactory.destroy()
         def indexFile = new File("./target/${reportDir}/index.xml")
@@ -45,8 +39,8 @@ class XmlReportIT extends Specification implements TestSupport {
         def reportXsltFile = new File("./target/${reportDir}/report.xslt")
 
         then:
-        resultSampleContext.failureCount == 0
-        resultContext.failureCount == 0
+        resultSampleContext.totalFailureCount == 0
+        resultContext.totalFailureCount == 0
         indexFile.exists()
         indexFile.length() > 0
         indexXsltFile.exists()

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/rest/NegativeRestScenariosIT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/rest/NegativeRestScenariosIT.groovy
@@ -1,24 +1,19 @@
 package org.jbehavesupport.core.rest
 
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
-import spock.lang.Shared
 import spock.lang.Specification
 
 class NegativeRestScenariosIT extends Specification implements TestSupport {
 
-    @Shared
-        runner = new JUnitCore()
-
     def "Should validate REST response via success handlers"() {
         when:
-        def result = runner.run(runWith("rest/NegativeRestHandling.story"))
+        def result = run(runWith("rest/NegativeRestHandling.story"))
 
         then:
         true
-        result.getFailureCount() == 3
-        result.getFailures().get(0).getMessage().contains("Expected response code is CREATED but was BAD_REQUEST")
-        result.getFailures().get(1).getMessage().contains("value 'sad' is not equal to 'happy'")
-        result.getFailures().get(2).getMessage().contains("value 'astronaut' is not equal to 'hippopotamus'")
+        result.getTotalFailureCount() == 3
+        result.getFailures().get(0).exception.getMessage().contains("Expected response code is CREATED but was BAD_REQUEST")
+        result.getFailures().get(1).exception.getMessage().contains("value 'sad' is not equal to 'happy'")
+        result.getFailures().get(2).exception.getMessage().contains("value 'astronaut' is not equal to 'hippopotamus'")
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/sql/CheckSqlError.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/sql/CheckSqlError.groovy
@@ -1,60 +1,54 @@
 package org.jbehavesupport.core.sql
 
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
-import org.junit.runner.Result
-import spock.lang.Issue
-import spock.lang.Shared
+import org.junit.platform.launcher.listeners.TestExecutionSummary
 import spock.lang.Specification
 
 class CheckSqlError extends Specification implements TestSupport {
 
-    @Shared
-        runner = new JUnitCore()
-
     def "check sql error for step: these columns from the single-row query result are saved:\$storedData"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorForSingleRowSaved.story"))
+        def result = run(runWith("sql/CheckSqlErrorForSingleRowSaved.story"))
 
         then:
-        result.failures.stream().anyMatch({ e -> e.exception.message.contains("Table \"PERSON_\" not found") })
+        result.failures.stream().anyMatch({ e -> e.exception.cause.message.contains("Table \"PERSON_\" not found") })
     }
 
     def "check sql error for step: these columns from the multi-row query result are saved:\$storedData"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorForMultiRowSaved.story"))
+        def result = run(runWith("sql/CheckSqlErrorForMultiRowSaved.story"))
 
         then:
-        result.failures.stream().anyMatch({ e -> e.exception.message.contains("Table \"PERSON_\" not found") })
+        result.failures.stream().anyMatch({ e -> e.exception.cause.message.contains("Table \"PERSON_\" not found") })
     }
 
     def "check sql error for step: these columns from the query result are equal:\$columnsToCompare"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorForColumnsFromQueryAreEqual.story"))
+        def result = run(runWith("sql/CheckSqlErrorForColumnsFromQueryAreEqual.story"))
 
         then:
-        result.failures.stream().anyMatch({ e -> e.exception.message.contains("Table \"PERSON_\" not found") })
+        result.failures.stream().anyMatch({ e -> e.exception.cause.message.contains("Table \"PERSON_\" not found") })
     }
 
     def "check sql error for step: these rows match the query result:\$matchingData"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorForRowsMatchQueryResult.story"))
+        def result = run(runWith("sql/CheckSqlErrorForRowsMatchQueryResult.story"))
 
         then:
-        result.failures.stream().anyMatch({ e -> e.exception.message.contains("Table \"PERSON_\" not found") })
+        result.failures.stream().anyMatch({ e -> e.exception.cause.message.contains("Table \"PERSON_\" not found") })
     }
 
     def "check sql error for step: these rows are present in the query result:\$presentData"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorForRowsArePresentInQueryResult.story"))
+        def result = run(runWith("sql/CheckSqlErrorForRowsArePresentInQueryResult.story"))
 
         then:
-        result.failures.stream().anyMatch({ e -> e.exception.message.contains("Table \"PERSON_\" not found") })
+        result.failures.stream().anyMatch({ e -> e.exception.cause.message.contains("Table \"PERSON_\" not found") })
     }
 
     def "check sql error for step: the result set has \$rowCount row(s)"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlResultHasCountRow.story"))
+        def result = run(runWith("sql/CheckSqlResultHasCountRow.story"))
 
         then:
         'assert error message'(result)
@@ -62,7 +56,7 @@ class CheckSqlError extends Specification implements TestSupport {
 
     def "this query is performed on [\$databaseId]:\$sqlStatement"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorForQueryIsPerformed.story"))
+        def result = run(runWith("sql/CheckSqlErrorForQueryIsPerformed.story"))
 
         then:
         'assert error message'(result)
@@ -70,21 +64,21 @@ class CheckSqlError extends Specification implements TestSupport {
 
     def "this update is performed on [\$databaseId]:\$sqlStatement"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorForQueryIsPerformed.story"))
+        def result = run(runWith("sql/CheckSqlErrorForQueryIsPerformed.story"))
 
         then:
         'assert error message'(result)
     }
 
-    private boolean 'assert error message'(Result result) {
-        result.failures.stream().anyMatch({ e -> e.exception.message.contains("Table \"PERSON_\" not found") })
+    private boolean 'assert error message'(TestExecutionSummary result) {
+        result.failures.stream().anyMatch({ e -> e.exception.cause.message.contains("Table \"PERSON_\" not found") })
     }
 
     def "check sql error for step: after scenario"() {
         when:
-        def result = runner.run(runWith("sql/CheckSqlErrorAfterScenario.story"))
+        def result = run(runWith("sql/CheckSqlErrorAfterScenario.story"))
 
         then:
-        result.failures.stream().anyMatch({ e -> e.exception.message.contains("Table \"PERSON_\" not found") })
+        result.failures.stream().anyMatch({ e -> e.exception.cause.message.contains("Table \"PERSON_\" not found") })
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/sql/DifferentDatabaseResultErrorMessage.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/sql/DifferentDatabaseResultErrorMessage.groovy
@@ -1,18 +1,13 @@
 package org.jbehavesupport.core.sql
 
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
-import spock.lang.Issue
-import spock.lang.Shared
 import spock.lang.Specification
 
 class DifferentDatabaseResultErrorMessage extends Specification implements TestSupport {
-    @Shared
-        runner = new JUnitCore()
 
     def "differentDatabaseResultPresent"() {
         when:
-        def result = runner.run(runWith("sql/DifferentDatabaseResultPresent.story"))
+        def result = run(runWith("sql/DifferentDatabaseResultPresent.story"))
 
         then:
         result.failures.stream().anyMatch({ e -> e.exception.message.contains("Result set does not contain expected data") })
@@ -34,22 +29,22 @@ class DifferentDatabaseResultErrorMessage extends Specification implements TestS
 
     def "differentDatabaseResultMatch"() {
         when:
-        def result = runner.run(runWith("sql/DifferentDatabaseResultMatch.story"))
+        def result = run(runWith("sql/DifferentDatabaseResultMatch.story"))
 
         then:
-        result.getFailureCount() == 1
-        result.getFailures().get(0).getMessage().contains("[row [0], column [AGE]]")
-        result.getFailures().get(0).getMessage().contains("value '31' is not equal to '1'")
-        result.getFailures().get(0).getMessage().contains("[row [0], column [FN]]")
-        result.getFailures().get(0).getMessage().contains("value 'John' is not equal to 'Dummy'")
-        result.getFailures().get(0).getMessage().contains("[row [0], column [LAST_UPDATE]]")
-        result.getFailures().get(0).getMessage().contains("value '2018-06-18' is not equal to '2001-06-18")
-        result.getFailures().get(0).getMessage().contains("[row [0], column [LN]]")
-        result.getFailures().get(0).getMessage().contains("value 'Doe' is not equal to 'Does't'")
-        result.getFailures().get(0).getMessage().contains("[row [2], column [FN]]")
-        result.getFailures().get(0).getMessage().contains("value 'Michael' is not equal to 'null'")
-        result.getFailures().get(0).getMessage().contains("[row [2], column [LN]]")
-        result.getFailures().get(0).getMessage().contains("value 'Doe' is not equal to 'null'")
+        result.getTotalFailureCount() == 1
+        result.getFailures().get(0).exception.getMessage().contains("[row [0], column [AGE]]")
+        result.getFailures().get(0).exception.getMessage().contains("value '31' is not equal to '1'")
+        result.getFailures().get(0).exception.getMessage().contains("[row [0], column [FN]]")
+        result.getFailures().get(0).exception.getMessage().contains("value 'John' is not equal to 'Dummy'")
+        result.getFailures().get(0).exception.getMessage().contains("[row [0], column [LAST_UPDATE]]")
+        result.getFailures().get(0).exception.getMessage().contains("value '2018-06-18' is not equal to '2001-06-18")
+        result.getFailures().get(0).exception.getMessage().contains("[row [0], column [LN]]")
+        result.getFailures().get(0).exception.getMessage().contains("value 'Doe' is not equal to 'Does't'")
+        result.getFailures().get(0).exception.getMessage().contains("[row [2], column [FN]]")
+        result.getFailures().get(0).exception.getMessage().contains("value 'Michael' is not equal to 'null'")
+        result.getFailures().get(0).exception.getMessage().contains("[row [2], column [LN]]")
+        result.getFailures().get(0).exception.getMessage().contains("value 'Doe' is not equal to 'null'")
 
     }
 

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/web/WebPropertyNegativeIT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/web/WebPropertyNegativeIT.groovy
@@ -1,28 +1,23 @@
 package org.jbehavesupport.core.web
 
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
-import spock.lang.Shared
 import spock.lang.Specification
 
 class WebPropertyNegativeIT extends Specification implements TestSupport {
 
-    @Shared
-    runner = new JUnitCore()
-
     def "Soft assertions of web properties"() {
         when:
-        def result = runner.run(runWith("web/WebPropertyNegative.story"))
+        def result = run(runWith("web/WebPropertyNegative.story"))
 
         then:
-        result.getFailureCount() == 1
-        result.getFailures().get(0).getMessage().contains("[element [#enabled-btn], property [ENABLED]] ")
-        result.getFailures().get(0).getMessage().contains("value 'true' is not equal to 'false'")
-        result.getFailures().get(0).getMessage().contains("[element [#disabled-btn], property [ENABLED]]")
-        result.getFailures().get(0).getMessage().contains("value 'false' is not equal to 'true'")
-        result.getFailures().get(0).getMessage().contains("[element [#class], property [CLASS]]")
-        result.getFailures().get(0).getMessage().contains("value 'my-class' is not equal to 'no-class'")
-        result.getFailures().get(0).getMessage().contains("[element [#select], property [SELECTED_TEXT]] ")
-        result.getFailures().get(0).getMessage().contains("value 'two' is not equal to 'one'")
+        result.getTotalFailureCount() == 1
+        result.getFailures().get(0).exception.getMessage().contains("[element [#enabled-btn], property [ENABLED]] ")
+        result.getFailures().get(0).exception.getMessage().contains("value 'true' is not equal to 'false'")
+        result.getFailures().get(0).exception.getMessage().contains("[element [#disabled-btn], property [ENABLED]]")
+        result.getFailures().get(0).exception.getMessage().contains("value 'false' is not equal to 'true'")
+        result.getFailures().get(0).exception.getMessage().contains("[element [#class], property [CLASS]]")
+        result.getFailures().get(0).exception.getMessage().contains("value 'my-class' is not equal to 'no-class'")
+        result.getFailures().get(0).exception.getMessage().contains("[element [#select], property [SELECTED_TEXT]] ")
+        result.getFailures().get(0).exception.getMessage().contains("value 'two' is not equal to 'one'")
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/web/YamlElementLocatorParserTest.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/web/YamlElementLocatorParserTest.groovy
@@ -5,7 +5,7 @@ import org.jbehavesupport.core.internal.web.YamlElementLocatorParser
 import org.jbehavesupport.core.internal.web.by.ByFactoryResolverImpl
 import org.jbehavesupport.core.internal.web.by.CssByFactory
 import org.jbehavesupport.core.internal.web.by.XpathByFactory
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import static org.openqa.selenium.By.cssSelector
 import static org.openqa.selenium.By.xpath

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/RequestResponseAliasIT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/RequestResponseAliasIT.groovy
@@ -1,19 +1,13 @@
 package org.jbehavesupport.core.ws
 
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
-import spock.lang.Issue
-import spock.lang.Shared
 import spock.lang.Specification
 
 class RequestResponseAliasIT extends Specification implements TestSupport {
 
-    @Shared
-        runner = new JUnitCore()
-
     def "Test us request response aliases"() {
         when:
-        def result = runner.run(runWith("ws/RequestResponseAlias.story"))
+        def result = run(runWith("ws/RequestResponseAlias.story"))
 
         then:
         result.failures.isEmpty()

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/SimpleListIT.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/SimpleListIT.groovy
@@ -1,19 +1,13 @@
 package org.jbehavesupport.core.ws
 
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
-import spock.lang.Issue
-import spock.lang.Shared
 import spock.lang.Specification
 
 class SimpleListIT extends Specification implements TestSupport {
 
-    @Shared
-        runner = new JUnitCore()
-
     def "Test simple string list"() {
         when:
-        def result = runner.run(runWith("ws/SimpleList.story"))
+        def result = run(runWith("ws/SimpleList.story"))
 
         then:
         result.failures.isEmpty()

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/ValidateWsResponse.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/core/ws/ValidateWsResponse.groovy
@@ -1,21 +1,15 @@
 package org.jbehavesupport.core.ws
 
 import org.jbehavesupport.test.support.TestSupport
-import org.junit.runner.JUnitCore
-import spock.lang.Issue
-import spock.lang.Shared
 import spock.lang.Specification
 
-
 class ValidateWsResponse extends Specification implements TestSupport {
-    @Shared
-        runner = new JUnitCore()
 
     def "Test failing context"() {
         when:
-        def result = runner.run(runWith("ws/ValidateWsResponse.story"))
+        def result = run(runWith("ws/ValidateWsResponse.story"))
 
         then:
-        result.failureCount == 0
+        result.totalFailureCount == 0
     }
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/SampleStoriesIT.java
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/SampleStoriesIT.java
@@ -3,23 +3,21 @@ package org.jbehavesupport.test.sample;
 import org.jbehavesupport.core.AbstractSpringStories;
 import org.jbehavesupport.test.support.SshContainer;
 import org.jbehavesupport.test.support.TestConfig;
-import org.junit.ClassRule;
-import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Arrays;
 import java.util.List;
 
-// spring junit4 runner needed for testcontainer lifecycle by classrule to work
-@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestConfig.class)
 public class SampleStoriesIT extends AbstractSpringStories {
 
-    @ClassRule
     public static SshContainer sshContainer = new SshContainer();
+
+    static {
+        sshContainer.start();
+    }
 
     @DynamicPropertySource
     static void sshProperties(DynamicPropertyRegistry registry) {

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Sql.story
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/Sql.story
@@ -114,7 +114,7 @@ Scenario: Query fails with message
 
 Given this query with expected exception is performed on [TEST]:
 select first_name from person_
-Then query fails and error message contains: Table "PERSON_" not found
+Then query fails and error message contains: bad SQL grammar
 
 
 Scenario: NULL command in step - these rows are present in the query result

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/report/ReportSampleStoriesIT.java
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/sample/report/ReportSampleStoriesIT.java
@@ -3,23 +3,21 @@ package org.jbehavesupport.test.sample.report;
 import org.jbehavesupport.core.AbstractSpringStories;
 import org.jbehavesupport.test.support.SshContainer;
 import org.jbehavesupport.test.support.TestConfig;
-import org.junit.ClassRule;
-import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Arrays;
 import java.util.List;
 
-// spring junit4 runner needed for testcontainer lifecycle by classrule to work
-@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestConfig.class)
 public class ReportSampleStoriesIT extends AbstractSpringStories {
 
-    @ClassRule
     public static SshContainer sshContainer = new SshContainer();
+
+    static {
+        sshContainer.start();
+    }
 
     @DynamicPropertySource
     static void sshProperties(DynamicPropertyRegistry registry) {

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestSupport.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestSupport.groovy
@@ -2,11 +2,37 @@ package org.jbehavesupport.test.support
 
 
 import org.jbehavesupport.test.GenericStory
+import org.junit.platform.launcher.Launcher
+import org.junit.platform.launcher.LauncherDiscoveryRequest
+import org.junit.platform.launcher.LauncherSession
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
+import org.junit.platform.launcher.core.LauncherFactory
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener
+import org.junit.platform.launcher.listeners.TestExecutionSummary
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 
 trait TestSupport {
 
-    Class runWith(String storyFile) {
+    @Shared
+    @AutoCleanup
+    LauncherSession session = LauncherFactory.openSession()
+
+    LauncherDiscoveryRequest runWith(String storyFile) {
         GenericStory.STORY_FILE = "org/jbehavesupport/core/" + storyFile
-        return GenericStory
+
+        LauncherDiscoveryRequestBuilder.request()
+            .selectors(selectClass(GenericStory))
+            .build()
     }
+
+    TestExecutionSummary run(LauncherDiscoveryRequest request) {
+        SummaryGeneratingListener listener = new SummaryGeneratingListener()
+        Launcher launcher = session.getLauncher()
+        launcher.execute(request, listener)
+        listener.getSummary()
+    }
+
 }

--- a/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestSupportBrowserStack.groovy
+++ b/jbehave-support-core/src/test/groovy/org/jbehavesupport/test/support/TestSupportBrowserStack.groovy
@@ -1,15 +1,8 @@
 package org.jbehavesupport.test.support
 
-import org.jbehavesupport.test.GenericStory
-
 import java.time.LocalDate
 
-trait TestSupportBrowserStack {
-
-    Class runWith(String storyFile) {
-        GenericStory.STORY_FILE = "org/jbehavesupport/test/" + storyFile
-        return GenericStory
-    }
+trait TestSupportBrowserStack extends TestSupport {
 
     String getBuildName() {
         return LocalDate.now().toString()

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.4</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -67,7 +67,7 @@
         <java.version>17</java.version>
 
         <version.jbehave>4.8.3</version.jbehave>
-        <version.jbehave-junit-support>4.8.3</version.jbehave-junit-support>
+        <version.jbehave-junit-support>4.8.3.1</version.jbehave-junit-support>
         <version.spockframework>2.4-M1-groovy-4.0</version.spockframework>
         <version.sshj>0.32.0</version.sshj>
         <version.webdrivermanager>5.1.0</version.webdrivermanager>
@@ -75,6 +75,8 @@
         <version.commons-collections4>4.4</version.commons-collections4>
         <version.moxy>4.0.0</version.moxy>
         <version.testcontainers>1.16.3</version.testcontainers>
+        <!-- TODO: Actions.click() seems to fail with an error on selenium 4, we should investigate and fix this -->
+        <selenium.version>3.141.59</selenium.version>
 
         <plugin.version.gmavenplus-plugin>1.13.1</plugin.version.gmavenplus-plugin>
         <plugin.version.maven-release-plugin>2.5.3</plugin.version.maven-release-plugin>


### PR DESCRIPTION
Migrate to JUnit5 - both in unit tests using jupiter engine and in story files using the custom jbehave engine.

Removed vintage engine (junit4), backwards incompatible change in health check steps since it leaked junit4 API, replaced with soft assertion.

**Snyk is angry due to selenium downgrade - will be fixed later by #769**