### PR TITLE
'Fix' report template for scenarios with examples

### DIFF
--- a/jbehave-support-core/src/main/resources/report-generator/stacktrace.xslt
+++ b/jbehave-support-core/src/main/resources/report-generator/stacktrace.xslt
@@ -17,7 +17,7 @@
                     <div class="modal-body">
                         <div class="form-group">
                             <textarea class="form-control" wrap="off" readonly="true" rows="26">
-                                <xsl:value-of select="../failure"/>
+                                <xsl:value-of select="../../failure"/>
                             </textarea>
                         </div>
                     </div>


### PR DESCRIPTION
 - fix no steps in report issue
 - fix broken link in stacktrace
 - add support for parametrized scenarios in report

known parametrized scenario report issues:
 - steps with example tables are printed on one line include table (broken formating) - unexpected behaviour of xml report - just don;t put them there, use save as value step to avoid it
 - Stacktrace button is broken - wierd XML report failure possition
 - no support for story level examples 
   - (to have it working use story level examples in LifeCycle bellow narative)
   - scenarui name is overriden by example values - jbehave feature probably

know/possible general report issues:
- stories are untitlet in xml report, first scenario name is taken as Story name - wrong
- possible not working links to failed screenshot - need testing

todo:
- document how to use examples to have it at least little usable